### PR TITLE
Small bug fix on custom path to databases metadata folder

### DIFF
--- a/basedosdados/base.py
+++ b/basedosdados/base.py
@@ -163,7 +163,7 @@ class Base:
                 no_question=("\nWhere would you like to save it?\n" "metadata path: "),
             )
 
-            c_file["metadata_path"] = str(metadata_path / "bases")
+            c_file["metadata_path"] = str(Path(metadata_path) / "bases")
 
             ############# STEP 2 - CREDENTIALS PATH #######################
 


### PR DESCRIPTION
Prior to this fix, an / operator was applied between two strings if a custom path to metadata folder was provided. This operation should use a PosixPath to create a path. I fixed this by turning the string that represents the custom path into a PosixPath.