### PR TITLE
Adiciona documentação do CLI

### DIFF
--- a/basedosdados/cli.py
+++ b/basedosdados/cli.py
@@ -18,9 +18,7 @@ from basedosdados import download
 def cli(ctx, templates, bucket_name, metadata_path):
 
     ctx.obj = dict(
-        templates=templates,
-        bucket_name=bucket_name,
-        metadata_path=metadata_path,
+        templates=templates, bucket_name=bucket_name, metadata_path=metadata_path,
     )
 
 
@@ -34,9 +32,7 @@ def cli_dataset(ctx):
 @cli_dataset.command(name="init", help="Initialize metadata files of dataset")
 @click.argument("dataset_id")
 @click.option(
-    "--replace",
-    is_flag=True,
-    help="Whether to replace current metadata files",
+    "--replace", is_flag=True, help="Whether to replace current metadata files",
 )
 @click.pass_context
 def init_dataset(ctx, dataset_id, replace):
@@ -78,12 +74,7 @@ def create_dataset(ctx, dataset_id, mode, if_exists):
 
     Dataset(dataset_id=dataset_id, **ctx.obj).create(mode=mode, if_exists=if_exists)
 
-    click.echo(
-        click.style(
-            mode_text(mode, "created", dataset_id),
-            fg="green",
-        )
-    )
+    click.echo(click.style(mode_text(mode, "created", dataset_id), fg="green",))
 
 
 @cli_dataset.command(name="update", help="Update dataset on BigQuery")
@@ -96,12 +87,7 @@ def update_dataset(ctx, dataset_id, mode):
 
     Dataset(dataset_id=dataset_id, **ctx.obj).update(mode=mode)
 
-    click.echo(
-        click.style(
-            mode_text(mode, "updated", dataset_id),
-            fg="green",
-        )
-    )
+    click.echo(click.style(mode_text(mode, "updated", dataset_id), fg="green",))
 
 
 @cli_dataset.command(name="publicize", help="Make a dataset public")
@@ -111,12 +97,7 @@ def publicize_dataset(ctx, dataset_id):
 
     Dataset(dataset_id=dataset_id, **ctx.obj).publicize()
 
-    click.echo(
-        click.style(
-            f"Dataset `{dataset_id}` became public!",
-            fg="green",
-        )
-    )
+    click.echo(click.style(f"Dataset `{dataset_id}` became public!", fg="green",))
 
 
 @cli_dataset.command(name="delete", help="Delete dataset")
@@ -131,12 +112,7 @@ def delete_dataset(ctx, dataset_id, mode):
 
         Dataset(dataset_id=dataset_id, **ctx.obj).delete(mode=mode)
 
-    click.echo(
-        click.style(
-            mode_text(mode, "deleted", dataset_id),
-            fg="green",
-        )
-    )
+    click.echo(click.style(mode_text(mode, "deleted", dataset_id), fg="green",))
 
 
 @click.group(name="table")
@@ -187,14 +163,10 @@ def init_table(ctx, dataset_id, table_id, data_sample_path, if_exists):
     "--job_config_params", default=None, help="File to advanced load config params "
 )
 @click.option(
-    "--partitioned",
-    is_flag=True,
-    help="[True|False] whether folder has partitions",
+    "--partitioned", is_flag=True, help="[True|False] whether folder has partitions",
 )
 @click.option(
-    "--if_exists",
-    default="raise",
-    help="[raise|replace|pass] actions if table exists",
+    "--if_exists", default="raise", help="[raise|replace|pass] actions if table exists",
 )
 @click.option(
     "--force_dataset",
@@ -240,9 +212,7 @@ def create_table(
 @click.pass_context
 def update_table(ctx, dataset_id, table_id, mode):
 
-    Table(table_id=table_id, dataset_id=dataset_id, **ctx.obj).update(
-        mode=mode,
-    )
+    Table(table_id=table_id, dataset_id=dataset_id, **ctx.obj).update(mode=mode,)
 
     click.echo(
         click.style(
@@ -256,9 +226,7 @@ def update_table(ctx, dataset_id, table_id, mode):
 @click.argument("dataset_id")
 @click.argument("table_id")
 @click.option(
-    "--if_exists",
-    default="raise",
-    help="[raise|replace] actions if table exists",
+    "--if_exists", default="raise", help="[raise|replace] actions if table exists",
 )
 @click.pass_context
 def publish_table(ctx, dataset_id, table_id, if_exists):
@@ -269,8 +237,7 @@ def publish_table(ctx, dataset_id, table_id, if_exists):
 
     click.echo(
         click.style(
-            f"Table `{dataset_id}.{table_id}` was published in BigQuery",
-            fg="green",
+            f"Table `{dataset_id}.{table_id}` was published in BigQuery", fg="green",
         )
     )
 
@@ -282,9 +249,7 @@ def publish_table(ctx, dataset_id, table_id, if_exists):
 @click.pass_context
 def delete_table(ctx, dataset_id, table_id, mode):
 
-    Table(table_id=table_id, dataset_id=dataset_id, **ctx.obj).delete(
-        mode=mode,
-    )
+    Table(table_id=table_id, dataset_id=dataset_id, **ctx.obj).delete(mode=mode,)
 
 
 @cli_table.command(name="append", help="Append new data to existing table")
@@ -293,9 +258,7 @@ def delete_table(ctx, dataset_id, table_id, mode):
 @click.argument("filepath", type=click.Path(exists=True))
 @click.option("--partitions", help="Data partition as `value=key/value2=key2`")
 @click.option(
-    "--if_exists",
-    default="raise",
-    help="[raise|replace|pass] if file alread exists",
+    "--if_exists", default="raise", help="[raise|replace|pass] if file alread exists",
 )
 @click.pass_context
 def upload_table(ctx, dataset_id, table_id, filepath, partitions, if_exists):
@@ -304,12 +267,7 @@ def upload_table(ctx, dataset_id, table_id, filepath, partitions, if_exists):
         filepath=filepath, partitions=partitions, if_exists=if_exists
     )
 
-    click.echo(
-        click.style(
-            f"Data was added to `{dataset_id}.{table_id}`",
-            fg="green",
-        )
-    )
+    click.echo(click.style(f"Data was added to `{dataset_id}.{table_id}`", fg="green",))
 
 
 @click.group(name="storage")
@@ -320,9 +278,7 @@ def cli_storage():
 @cli_storage.command(name="init", help="Create bucket and initial folders")
 @click.option("--bucket_name", default="basedosdados", help="Bucket name")
 @click.option(
-    "--replace",
-    is_flag=True,
-    help="Whether to replace current bucket files",
+    "--replace", is_flag=True, help="Whether to replace current bucket files",
 )
 @click.option(
     "--very-sure/--not-sure",
@@ -338,12 +294,7 @@ def init_storage(ctx, bucket_name, replace, very_sure):
         replace=replace, very_sure=very_sure
     )
 
-    click.echo(
-        click.style(
-            f"Bucket `{bucket_name}` was created",
-            fg="green",
-        )
-    )
+    click.echo(click.style(f"Bucket `{bucket_name}` was created", fg="green",))
 
 
 @cli_storage.command(name="upload", help="Upload file to bucket")
@@ -355,9 +306,7 @@ def init_storage(ctx, bucket_name, replace, very_sure):
 )
 @click.option("--partitions", help="Data partition as `value=key/value2=key2`")
 @click.option(
-    "--if_exists",
-    default="raise",
-    help="[raise|replace|pass] if file alread exists",
+    "--if_exists", default="raise", help="[raise|replace|pass] if file alread exists",
 )
 @click.pass_context
 def upload_storage(ctx, dataset_id, table_id, filepath, mode, partitions, if_exists):
@@ -367,12 +316,7 @@ def upload_storage(ctx, dataset_id, table_id, filepath, mode, partitions, if_exi
         filepath=filepath, mode=mode, partitions=partitions, if_exists=if_exists
     )
 
-    click.echo(
-        click.style(
-            f"Data was added to `{blob_name}`",
-            fg="green",
-        )
-    )
+    click.echo(click.style(f"Data was added to `{blob_name}`", fg="green",))
 
 
 @click.group(name="config")
@@ -397,12 +341,9 @@ def init_refresh_templates(ctx):
 @click.command(
     name="download",
     help="Download data. "
-    "You can add extra arguments accepted by pandas.to_csv. "
+    "You can add extra arguments accepted by `pandas.to_csv`.\n\n"
     "Examples: --delimiter='|', --index=False",
-    context_settings=dict(
-        ignore_unknown_options=True,
-        allow_extra_args=True,
-    ),
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True,),
 )
 @click.argument("savepath", type=click.Path(exists=False))
 @click.option(
@@ -416,14 +357,10 @@ def init_refresh_templates(ctx):
     help="Table_id, enter with dataset_id to download table ",
 )
 @click.option(
-    "--query",
-    default=None,
-    help="A SQL Standard query to download data from BigQuery",
+    "--query", default=None, help="A SQL Standard query to download data from BigQuery",
 )
 @click.option(
-    "--limit",
-    default=None,
-    help="Number of rows returned",
+    "--limit", default=None, help="Number of rows returned",
 )
 @click.pass_context
 def cli_download(ctx, dataset_id, table_id, savepath, query, limit):
@@ -441,12 +378,7 @@ def cli_download(ctx, dataset_id, table_id, savepath, query, limit):
         **pandas_kwargs,
     )
 
-    click.echo(
-        click.style(
-            f"Table was downloaded to `{savepath}`",
-            fg="green",
-        )
-    )
+    click.echo(click.style(f"Table was downloaded to `{savepath}`", fg="green",))
 
 
 cli.add_command(cli_dataset)

--- a/basedosdados/cli.py
+++ b/basedosdados/cli.py
@@ -12,7 +12,7 @@ from basedosdados import download
 
 @click.group()
 @click.option("--templates", default=None, help="Templates path")
-@click.option("--bucket_name", default=None, help="Project bucket_name name")
+@click.option("--bucket_name", default=None, help="Project bucket name")
 @click.option("--metadata_path", default=None, help="Folder to store metadata")
 @click.pass_context
 def cli(ctx, templates, bucket_name, metadata_path):

--- a/docs/cli_reference_api.md
+++ b/docs/cli_reference_api.md
@@ -1,1 +1,23 @@
-## Comandos CLI
+# CLI API
+
+Esta API é composta de comandos para **gerenciamento e inserção de
+dados** no Google Cloud.
+
+Os comandos disponíveis dentro de `cli` atualmente são:
+
+- `config`, que é utilizado para atualizar seus dados de configuração e
+ gerenciar templates
+- `dataset`, que permite gerenciar datasets no BigQuery (criar,
+  modificar, publicar , atualizar e deletar)
+- `download`, que permite baixar/salvar queries de tabelas do BigQuery na sua máquina local
+- `storage`, que permite gerenciar seu Storage no BigQuery (criar e
+  subir arquivos)
+- `table`, que permite gerenciar tabelas no BigQuery (criar,
+  modificar, publicar , atualizar e deletar)
+
+!!! Info "Toda documentação do código abaixo está em inglês"
+
+::: mkdocs-click
+    :module: basedosdados.cli
+    :command: cli
+    :depth: 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.tabbed
   - pymdownx.superfences
+  - mkdocs-click
 
 google_analytics:
   - !!python/object/apply:os.getenv ["GOOGLE_ANALYTICS_KEY"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ mkdocs-material
 flake8
 mkdocstrings
 pandas_gbq
+mkdocs-click


### PR DESCRIPTION
Usando `mkdocs-click` 🙂 

Não é tão bonito visualmente quanto o `mkdocstrings` - este último só tem `handler` para Python por enquanto.

TODO:
- Adicionar docstrings nos comandos gerais do CLI:
  - `cli`
  - `config`
  - `download`
  - `dataset`
  - `storage`
  - `table` --> o que faz exatamente o `update` aqui, sobrescreve numa tabela já existente? não seria o mesmo de `publish --if_exists replace`?