### PR TITLE
[infra] Corrige issue #267: 

### DIFF
--- a/basedosdados/storage.py
+++ b/basedosdados/storage.py
@@ -160,7 +160,7 @@ class Storage(Base):
             parts = [
                 (
                     filepath.as_posix()
-                    .replace(str(path) + "/", "")
+                    .replace(path.as_posix() + "/", "")
                     .replace(str(filepath.name), "")
                 )
                 for filepath in paths

--- a/basedosdados/storage.py
+++ b/basedosdados/storage.py
@@ -159,7 +159,7 @@ class Storage(Base):
 
             parts = [
                 (
-                    str(filepath)
+                    filepath.as_posix()
                     .replace(str(path) + "/", "")
                     .replace(str(filepath.name), "")
                 )

--- a/basedosdados/table.py
+++ b/basedosdados/table.py
@@ -176,7 +176,7 @@ class Table(Base):
 
                 partition_columns = [
                     k.split("=")[0]
-                    for k in str(data_sample_path).split("/")
+                    for k in data_sample_path.as_posix().split("/")
                     if "=" in k
                 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/base-dos-dados/bases"
-version = "1.4.1"
+version = "1.4.2"
 
 [tool.poetry.scripts]
 basedosdados = 'basedosdados.cli:cli'


### PR DESCRIPTION
    Um fix simples para esse problema de paths seria usar o pathlib.Path.as_posix() 
no trecho do código em que se dá parse nas partições. 
    Visto que o problema está na manipulação de strings e não realmente na hora de se fazer
 uma chamada no caminho real do arquivo.
   Tentei alguns jeitos diferentes, porém a mudança para métodos do ### os acaba deixando o código mais poluído e menos legivel. 