### PR TITLE
[infra] In function publish, forced query to complete before updating table

### DIFF
--- a/basedosdados/table.py
+++ b/basedosdados/table.py
@@ -424,7 +424,7 @@ class Table(Base):
 
         self.client["bigquery_prod"].query(
             (self.table_folder / "publish.sql").open("r", encoding="utf-8").read()
-        )
+        ).result()
 
         self.update("prod")
 


### PR DESCRIPTION
#276 

Como se publica VIEWS, é possível que ao fazer o update da table, a query da VIEW não tenha terminado ainda. A idéia é forçar a query terminar antes de prosseguir com o update da table.

Baseado na [referencia](https://googleapis.dev/python/bigquery/latest/index.html) do google (Na seção "Example Usage"), o a função `result()` de um job de query espera o resultado da query terminar.