### PR TITLE
Versao minima da dependencia readr.

### DIFF
--- a/r-package/DESCRIPTION
+++ b/r-package/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     googleAuthR,
     cli,
     magrittr,
-    readr,
+    readr (>= 1.4.0),
     stringr,
     dotenv,
     bigrquery,


### PR DESCRIPTION
A issue #411 apresenta uma usuária em que provavelmente a versao do readr que ela possui instalada causa um erro. Para evitar esse tipo de problema com dependencias, a boa prática da comunidade é adicionar a versao mínima dos packages. Entende-se como versao mínima, a versao das dependências quais foram utilizadas no momento do desenvolvimento.

O que o pull request faz é adicionar uma versao mínima para a `readr`, o que fará o `R` atualizar a dependencia caso a instalada no computador do usuário seja menor que a mínima necessária.  Deixo como recomendaçao aos desenvolvedores adicionar a versao mínima em todos as bibliotecas.

Mais informaçoes podem ser encontradas na [seçao 8.1.1 do livro R-Packages](https://r-pkgs.org/description.html), lá Wickham e Bryan, dizem:

> Versioning is most important when you release your package. Usually people don’t have exactly the same versions of packages installed that you do. If someone has an older package that doesn’t have a function your package needs, they’ll get an unhelpful error message. However, if you supply the version number, they’ll get a error message that tells them exactly what the problem is: an out of date package.

