### PR TITLE
[infra] update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ bases/test/
 mais/pytest/*
 mais/test/
 
+bases/*/input/
+bases/*/tmp/
+bases/*/output/
+
 notebooks
 data
 secrets


### PR DESCRIPTION
As pastas `input`, `output` e `tmp` dentro de `bases` não são enviadas para o repo, fazem parte do processo de limpeza, no entanto são trackeadas pelo git.

Essa PR adiciona as três no gitignore.