### PR TITLE
[docs] conserta join da query de exemplo `pib_per_capita`

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -3,7 +3,7 @@ name: update-contributors
 on:
   schedule:
     # “At 00:00 on Sunday.” - check: https://crontab.guru/#0_0_*_*_0
-    - cron:  '30 11 * * MON'
+    - cron:  '00 19 * * THU'
 
 jobs:
   update-levels:

--- a/docs/access_data_local.md
+++ b/docs/access_data_local.md
@@ -75,7 +75,7 @@ em todos os anos disponíveis**.
         pop.ano,  
         pib.PIB / pop.populacao * 1000 as pib_per_capita 
     FROM `basedosdados.br_ibge_pib.municipios` as pib 
-    INNER JOIN `basedosdados.br_ibge_populacao.municipios` as pop 
+    INNER JOIN `basedosdados.br_ibge_populacao.municipio` as pop 
     ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano
     LIMIT 100;'
     ```
@@ -91,7 +91,7 @@ em todos os anos disponíveis**.
         pop.ano, 
         pib.PIB / pop.populacao * 1000 as pib_per_capita
     FROM `basedosdados.br_ibge_pib.municipios` as pib
-    INNER JOIN `basedosdados.br_ibge_populacao.municipios` as pop
+    INNER JOIN `basedosdados.br_ibge_populacao.municipio` as pop
     ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano
     """
 
@@ -127,7 +127,7 @@ em todos os anos disponíveis**.
         pop.ano,
         pib.PIB / pop.populacao * 1000 as pib_per_capita
         FROM `basedosdados.br_ibge_pib.municipios` as pib
-        JOIN `basedosdados.br_ibge_populacao.municipios` as pop
+        JOIN `basedosdados.br_ibge_populacao.municipio` as pop
         ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano"
 
     # Você pode fazer o download no seu computador

--- a/docs/access_data_local.md
+++ b/docs/access_data_local.md
@@ -76,7 +76,7 @@ em todos os anos disponíveis**.
         pib.PIB / pop.populacao * 1000 as pib_per_capita 
     FROM `basedosdados.br_ibge_pib.municipios` as pib 
     INNER JOIN `basedosdados.br_ibge_populacao.municipios` as pop 
-    ON pib.id_municipio = pop.id_municipio AND pib.ano = pop.ano
+    ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano
     LIMIT 100;'
     ```
 
@@ -92,7 +92,7 @@ em todos os anos disponíveis**.
         pib.PIB / pop.populacao * 1000 as pib_per_capita
     FROM `basedosdados.br_ibge_pib.municipios` as pib
     INNER JOIN `basedosdados.br_ibge_populacao.municipios` as pop
-    ON pib.id_municipio = pop.id_municipio AND pib.ano = pop.ano
+    ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano
     """
 
     # Você pode fazer o download no seu computador
@@ -128,7 +128,7 @@ em todos os anos disponíveis**.
         pib.PIB / pop.populacao * 1000 as pib_per_capita
         FROM `basedosdados.br_ibge_pib.municipios` as pib
         JOIN `basedosdados.br_ibge_populacao.municipios` as pop
-        ON pib.id_municipio = pop.id_municipio AND pib.ano = pop.ano"
+        ON pib.id_municipio = CAST(pop.id_municipio AS INTEGER) AND pib.ano = pop.ano"
 
     # Você pode fazer o download no seu computador
     dir <- tempdir()


### PR DESCRIPTION
O join da query de exemplo `pib_per_capita` parecia estar quebrado, por conta de uma diferença nos tipos das colunas `id_municipio` em cada tabela. Proponho essa solução de converter o `id_municipio` da tabela `basedosdados.br_ibge_populacao.municipios` de `STRING` para `INTEGER` com a função `CAST`, mas não sei se é ideal. Além disso, a tabela `basedosdados.br_ibge_populacao.municipio` estava com o nome errado.