### PR TITLE
[infra] Configurar o basedosdados a partir de variáveis de ambiente

### DIFF
--- a/python-package/basedosdados/__init__.py
+++ b/python-package/basedosdados/__init__.py
@@ -1,11 +1,4 @@
-import sys
-import os
-
-sys.path.append(os.getcwd() + "/python-package")
-
-from basedosdados.upload.dataset import Dataset
-from basedosdados.upload.storage import Storage
-from basedosdados.upload.table import Table
+from basedosdados.constants import constants
 from basedosdados.download.download import (
     read_sql,
     download,
@@ -17,3 +10,10 @@ from basedosdados.download.download import (
     get_table_columns,
     get_table_size,
 )
+from basedosdados.upload.table import Table
+from basedosdados.upload.storage import Storage
+from basedosdados.upload.dataset import Dataset
+import sys
+import os
+
+sys.path.append(os.getcwd() + "/python-package")

--- a/python-package/basedosdados/constants.py
+++ b/python-package/basedosdados/constants.py
@@ -1,0 +1,30 @@
+__all__ = [
+    'constants'
+]
+
+# Decorator for making immutable attributes on classes
+
+
+def const(cls):
+    def is_special(name): return (
+        name.startswith("__") and name.endswith("__"))
+    class_contents = {n: getattr(cls, n)
+                      for n in vars(cls) if not is_special(n)}
+
+    def unbind(value):
+        return lambda self: value
+    propertified_contents = {
+        name: property(unbind(value)) for (name, value) in class_contents.items()
+    }
+    receptor = type(cls.__name__, (object,), propertified_contents)
+    return receptor()
+
+# Declare new constants here
+
+
+@const
+class constants (object):
+    env_config: str = "BASEDOSDADOS_CONFIG"
+    env_credentials_prefix: str = "BASEDOSDADOS_CREDENTIALS_"
+    env_credentials_prod: str = "BASEDOSDADOS_CREDENTIALS_PROD"
+    env_credentials_staging: str = "BASEDOSDADOS_CREDENTIALS_STAGING"

--- a/python-package/basedosdados/upload/base.py
+++ b/python-package/basedosdados/upload/base.py
@@ -6,6 +6,10 @@ from pathlib import Path
 import shutil
 import tomlkit
 import warnings
+import json
+import base64
+from os import getenv
+from basedosdados import constants
 
 from functools import lru_cache
 
@@ -27,16 +31,29 @@ class Base:
         self.config = self._load_config()
 
         self.templates = Path(templates or self.config["templates_path"])
-        self.metadata_path = Path(metadata_path or self.config["metadata_path"])
+        self.metadata_path = Path(
+            metadata_path or self.config["metadata_path"])
         self.bucket_name = bucket_name or self.config["bucket_name"]
         self.uri = f"gs://{self.bucket_name}" + "/staging/{dataset}/{table}/*"
 
-    def _load_credentials(self, mode):
+    @staticmethod
+    def _decode_env(env: str) -> str:
+        return base64.b64decode(getenv(env).encode('utf-8')).decode('utf-8')
 
-        return service_account.Credentials.from_service_account_file(
-            self.config["gcloud-projects"][mode]["credentials_path"],
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
-        )
+    def _load_credentials(self, mode: str):
+
+        if getenv(f"{constants.env_credentials_prefix}{mode.upper()}"):
+            info = json.loads(self._decode_env(
+                f"{constants.env_credentials_prefix}{mode.upper()}"))
+            return service_account.Credentials.from_service_account_info(
+                info, scopes=[
+                    "https://www.googleapis.com/auth/cloud-platform"]
+            )
+        else:
+            return service_account.Credentials.from_service_account_file(
+                self.config["gcloud-projects"][mode]["credentials_path"],
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
 
     @property
     @lru_cache(256)
@@ -71,7 +88,7 @@ class Base:
 
         var = input(context)
 
-        to_lower = lambda x: x.lower() if with_lower else x
+        def to_lower(x): return x.lower() if with_lower else x
 
         if var:
             return to_lower(var.strip())
@@ -142,11 +159,30 @@ class Base:
         # Create template folder
         self._refresh_templates()
 
+        # If environments are set but no files exist
+        if (
+            (not config_file.exists()) and
+            (getenv(constants.env_config)) and
+            (getenv(constants.env_credentials_prod)) and
+            (getenv(constants.env_credentials_staging))
+        ):
+            # Create basedosdados files from envs
+            with open(config_file, "w") as f:
+                f.write(self._decode_env(constants.env_config))
+                f.close()
+            with open(credentials_folder / "prod.json", "w") as f:
+                f.write(self._decode_env(constants.env_credentials_prod))
+                f.close()
+            with open(credentials_folder / "staging.json", "w") as f:
+                f.write(self._decode_env(constants.env_credentials_staging))
+                f.close()
+
         if (not config_file.exists()) or (force):
 
             # Load config file
             c_file = tomlkit.parse(
-                (Path(__file__).resolve().parents[1] / "configs" / "config.toml")
+                (Path(__file__).resolve(
+                ).parents[1] / "configs" / "config.toml")
                 .open("r", encoding="utf-8")
                 .read()
             )
@@ -170,7 +206,8 @@ class Base:
                 ),
                 default_yn="y",
                 default_return=Path.cwd(),
-                no_question=("\nWhere would you like to save it?\n" "metadata path: "),
+                no_question=(
+                    "\nWhere would you like to save it?\n" "metadata path: "),
                 with_lower=False,
             )
 
@@ -205,7 +242,8 @@ class Base:
                 "basedosdados-staging",
             )
 
-            self._check_credentials(project_staging, "staging", credentials_path)
+            self._check_credentials(
+                project_staging, "staging", credentials_path)
 
             c_file["gcloud-projects"]["staging"]["credentials_path"] = str(
                 credentials_path / "staging.json"
@@ -254,17 +292,25 @@ class Base:
 
             ############# STEP 6 - SET TEMPLATES #######################
 
-            c_file["templates_path"] = str(Path.home() / ".basedosdados" / "templates")
+            c_file["templates_path"] = str(
+                Path.home() / ".basedosdados" / "templates")
 
-            config_file.open("w", encoding="utf-8").write(tomlkit.dumps(c_file))
+            config_file.open(
+                "w", encoding="utf-8").write(tomlkit.dumps(c_file))
 
     def _load_config(self):
 
-        return tomlkit.parse(
-            (Path.home() / ".basedosdados" / "config.toml")
-            .open("r", encoding="utf-8")
-            .read()
-        )
+        from_env: str = getenv(
+            constants.env_config, "")
+        if from_env != "":
+            config = json.loads(self._decode_env(from_env))
+            return tomlkit.parse(config)
+        else:
+            return tomlkit.parse(
+                (Path.home() / ".basedosdados" / "config.toml")
+                .open("r", encoding="utf-8")
+                .read()
+            )
 
     def _load_yaml(self, file):
 

--- a/python-package/basedosdados/upload/base.py
+++ b/python-package/basedosdados/upload/base.py
@@ -300,10 +300,8 @@ class Base:
 
     def _load_config(self):
 
-        from_env: str = getenv(
-            constants.env_config, "")
-        if from_env != "":
-            config = json.loads(self._decode_env(from_env))
+        if getenv(constants.env_config):
+            config = json.loads(self._decode_env(constants.env_config))
             return tomlkit.parse(config)
         else:
             return tomlkit.parse(

--- a/python-package/basedosdados/upload/base.py
+++ b/python-package/basedosdados/upload/base.py
@@ -301,8 +301,7 @@ class Base:
     def _load_config(self):
 
         if getenv(constants.env_config):
-            config = json.loads(self._decode_env(constants.env_config))
-            return tomlkit.parse(config)
+            return tomlkit.parse(self._decode_env(constants.env_config))
         else:
             return tomlkit.parse(
                 (Path.home() / ".basedosdados" / "config.toml")


### PR DESCRIPTION
**Sua solicitação de recurso está relacionada a um problema? Por favor, descreva.**

Em certos ambientes, como _jobs_ lançadas pelo `K8sRunLauncher` do Dagster, não é possível (até o momento) montar volumes nos containers e nem é viável acessá-los para realizar a configuração do basedosdados. No entanto, ainda é possível configurar variáveis de ambiente, o que poderia permitir a configuração do basedosdados.

**Descreva a solução que você gostaria**

A implementação aqui submetida parte de uma configuração já realizada do basedosdados em uma máquina qualquer. Sendo assim, para gerar as variáveis de ambiente para os containers pode-se fazer:

```sh
export BASEDOSDADOS_CONFIG=$(cat ~/.basedosdados/config.toml | base64)
export BASEDOSDADOS_CREDENTIALS_PROD=$(cat ~/.basedosdados/credentials/prod.json | base64)
export BASEDOSDADOS_CREDENTIALS_STAGING=$(cat ~/.basedosdados/credentials/staging.json | base64)
```

Dessa forma, pode-se armazenar o valor dessas três variáveis de ambiente, codificados em base64 para maior compatibilidade, replicando-as em quantos containers forem necessários.

Para a implementação no python package, é realizada uma verificação da coexistência das três envs. Caso todas existam, tenta-se gerar os arquivos originais em `$HOME/.basedosdados` correspondentes a cada uma delas.

**Descreva alternativas que você considerou**

Foi considerado solicitar também a alteração aos desenvolvedores do Dagster, de forma a permitir volumes nesses containers. No entanto, como esse problema já foi constatado em março (https://github.com/dagster-io/dagster/issues/3871) e até o momento não houve implementação, acredita-se que pode demorar.
