### PR TITLE
[infra] fix default query and path mess in CI

### DIFF
--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -18,8 +18,8 @@ from basedosdados.validation.exceptions import BaseDosDadosException
 
 
 TEST_PROJECT_ID = "basedosdados-dev"
-SAVEFILE = Path("tests") / "tmp_bases" / "test.csv"
-SAVEPATH = Path("tests") / "tmp_bases"
+SAVEFILE = Path(__file__).parent / "tmp_bases" / "test.csv"
+SAVEPATH = Path(__file__).parent / "tmp_bases"
 shutil.rmtree(SAVEPATH, ignore_errors=True)
 
 
@@ -27,7 +27,7 @@ def test_download_by_query():
 
     download(
         SAVEFILE,
-        query="select * from `basedosdados.br_ibge_pib.municipios` limit 10",
+        query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
         billing_project_id=TEST_PROJECT_ID,
         index=False,
         from_file=True,
@@ -39,7 +39,7 @@ def test_download_by_query():
     with pytest.raises(BaseDosDadosException):
         download(
             SAVEFILE,
-            query="select * from `basedosdados.br_ibge_pib.municipios` limit 10",
+            query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
         )
 
 
@@ -48,7 +48,7 @@ def test_download_by_table():
     download(
         SAVEFILE,
         dataset_id="br_ibge_pib",
-        table_id="municipios",
+        table_id="municipio",
         billing_project_id=TEST_PROJECT_ID,
         limit=10,
         from_file=True,
@@ -62,7 +62,7 @@ def test_download_by_table():
         download(
             SAVEFILE,
             dataset_id="br_ibge_pib",
-            table_id="municipios",
+            table_id="municipio",
             limit=10,
         )
 
@@ -72,14 +72,14 @@ def test_download_save_to_path():
     download(
         SAVEPATH,
         dataset_id="br_ibge_pib",
-        table_id="municipios",
+        table_id="municipio",
         billing_project_id=TEST_PROJECT_ID,
         from_file=True,
         limit=10,
         index=False,
     )
 
-    assert (SAVEPATH / "municipios.csv").exists()
+    assert (SAVEPATH / "municipio.csv").exists()
 
 
 def test_download_no_query_or_table():
@@ -96,7 +96,7 @@ def test_download_pandas_kwargs():
     download(
         SAVEFILE,
         dataset_id="br_ibge_pib",
-        table_id="municipios",
+        table_id="municipio",
         billing_project_id=TEST_PROJECT_ID,
         from_file=True,
         limit=10,
@@ -111,7 +111,7 @@ def test_read_sql():
 
     assert isinstance(
         read_sql(
-            query="select * from `basedosdados.br_ibge_pib.municipios` limit 10",
+            query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
             billing_project_id=TEST_PROJECT_ID,
             from_file=True,
         ),
@@ -124,7 +124,7 @@ def test_read_table():
     assert isinstance(
         read_table(
             dataset_id="br_ibge_pib",
-            table_id="municipios",
+            table_id="municipio",
             billing_project_id=TEST_PROJECT_ID,
             from_file=True,
             limit=10,

--- a/python-package/tests/test_storage.py
+++ b/python-package/tests/test_storage.py
@@ -7,14 +7,15 @@ from basedosdados import Storage
 
 DATASET_ID = "pytest"
 TABLE_ID = "pytest"
-SAVEPATH = Path("tests") / "tmp_bases"
+SAVEPATH = Path(__file__).parent / "tmp_bases"
 
 TABLE_FILES = ["publish.sql", "table_config.yaml"]
 
 
 @pytest.fixture
 def metadatadir(tmpdir_factory):
-    return Path("tests") / "tmp_bases"
+    (Path(__file__).parent / "tmp_bases").mkdir(exist_ok=True)
+    return Path(__file__).parent / "tmp_bases"
 
 
 @pytest.fixture
@@ -24,24 +25,24 @@ def storage(metadatadir):
 
 def test_upload(storage, metadatadir):
 
-    storage.delete_file("municipios.csv", "staging", not_found_ok=True)
+    storage.delete_file("municipio.csv", "staging", not_found_ok=True)
 
-    storage.upload(metadatadir / "municipios.csv", mode="staging")
+    storage.upload(metadatadir / "municipio.csv", mode="staging")
 
     with pytest.raises(Exception):
-        storage.upload(metadatadir / "municipios.csv", mode="staging")
+        storage.upload(metadatadir / "municipio.csv", mode="staging")
 
-    storage.upload(metadatadir / "municipios.csv", mode="staging", if_exists="replace")
+    storage.upload(metadatadir / "municipio.csv", mode="staging", if_exists="replace")
 
     storage.upload(
-        metadatadir / "municipios.csv",
+        metadatadir / "municipio.csv",
         mode="staging",
         if_exists="replace",
         partitions="key1=value1/key2=value2",
     )
 
     storage.upload(
-        metadatadir / "municipios.csv",
+        metadatadir / "municipio.csv",
         mode="staging",
         if_exists="replace",
         partitions={"key1": "value1", "key2": "value1"},
@@ -49,7 +50,7 @@ def test_upload(storage, metadatadir):
 
     with pytest.raises(Exception):
         storage.upload(
-            metadatadir / "municipios.csv",
+            metadatadir / "municipio.csv",
             mode="staging",
             if_exists="replace",
             partitions=["key1", "value1", "key2", "value1"],
@@ -67,10 +68,10 @@ def test_download_not_found(storage):
 
 def test_download_filename(storage):
 
-    storage.download(filename="municipios.csv", savepath=SAVEPATH, mode="staging")
+    storage.download(filename="municipio.csv", savepath=SAVEPATH, mode="staging")
 
     assert (
-        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipios.csv"
+        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipio.csv"
     ).is_file()
 
 
@@ -89,7 +90,7 @@ def test_download_partitions(storage):
         / TABLE_ID
         / "key1=value1"
         / "key2=value1"
-        / "municipios.csv"
+        / "municipio.csv"
     ).is_file()
 
     storage.download(
@@ -105,7 +106,7 @@ def test_download_partitions(storage):
         / TABLE_ID
         / "key1=value1"
         / "key2=value2"
-        / "municipios.csv"
+        / "municipio.csv"
     ).is_file()
 
 
@@ -113,39 +114,39 @@ def test_download_default(storage):
     storage.download(savepath=SAVEPATH, mode="staging")
 
     assert (
-        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipios.csv"
+        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipio.csv"
     ).is_file()
 
     assert (
-        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipios2.csv"
+        Path(SAVEPATH) / "staging" / DATASET_ID / TABLE_ID / "municipio2.csv"
     ).is_file()
 
 
 def test_delete_file(storage):
 
-    storage.delete_file("municipios.csv", "staging")
+    storage.delete_file("municipio.csv", "staging")
 
     with pytest.raises(NotFound):
-        storage.delete_file("municipios.csv", "staging")
+        storage.delete_file("municipio.csv", "staging")
 
-    storage.delete_file("municipios.csv", "staging", not_found_ok=True)
+    storage.delete_file("municipio.csv", "staging", not_found_ok=True)
 
 
 def test_copy_table(storage):
 
-    Storage("br_ibge_pib", "municipios").copy_table()
+    Storage("br_ibge_pib", "municipio").copy_table()
 
     with pytest.raises(FileNotFoundError):
-        Storage("br_ibge_pib2", "municipios2").copy_table()
+        Storage("br_ibge_pib2", "municipio2").copy_table()
 
-    Storage("br_ibge_pib", "municipios").copy_table(
+    Storage("br_ibge_pib", "municipio").copy_table(
         destination_bucket_name="basedosdados-dev",
     )
 
 
 def test_delete_table(storage):
 
-    Storage("br_ibge_pib", "municipios").delete_table(bucket_name="basedosdados-dev")
+    Storage("br_ibge_pib", "municipio").delete_table(bucket_name="basedosdados-dev")
 
     with pytest.raises(FileNotFoundError):
-        Storage("br_ibge_pib", "municipios").delete_table()
+        Storage("br_ibge_pib", "municipio").delete_table()

--- a/python-package/tests/test_table.py
+++ b/python-package/tests/test_table.py
@@ -15,7 +15,8 @@ TABLE_FILES = ["publish.sql", "table_config.yaml"]
 
 @pytest.fixture
 def metadatadir(tmpdir_factory):
-    return Path("tests") / "tmp_bases"
+    (Path(__file__).parent / "tmp_bases").mkdir(exist_ok=True)
+    return Path(__file__).parent / "tmp_bases"
 
 
 @pytest.fixture
@@ -33,12 +34,12 @@ def folder(metadatadir):
 
 @pytest.fixture
 def data_path(metadatadir):
-    return Path(metadatadir) / "municipios.csv"
+    return Path(__file__).parent / "tmp_bases" / "municipio.csv"
 
 
 @pytest.fixture
 def sample_data(metadatadir):
-    return Path("tests") / "sample_data" / "table"
+    return Path(__file__).parent / "sample_data" / "table"
 
 
 def check_files(folder):
@@ -371,8 +372,8 @@ def test_create_auto_partitions(metadatadir, data_path, sample_data):
     for n in [1, 2]:
         Path(metadatadir / "partitions" / f"keys={n}").mkdir()
         shutil.copy(
-            metadatadir / "municipios.csv",
-            metadatadir / "partitions" / f"keys={n}" / "municipios.csv",
+            metadatadir / "municipio.csv",
+            metadatadir / "partitions" / f"keys={n}" / "municipio.csv",
         )
 
     table_part.create(
@@ -463,8 +464,8 @@ def test_publish(table, metadatadir, sample_data, data_path):
 
 def test_append(table, metadatadir):
     shutil.copy(
-        metadatadir / "municipios.csv",
-        metadatadir / "municipios2.csv",
+        metadatadir / "municipio.csv",
+        metadatadir / "municipio2.csv",
     )
 
-    table.append((metadatadir / "municipios2.csv"), if_exists="replace")
+    table.append((metadatadir / "municipio2.csv"), if_exists="replace")


### PR DESCRIPTION
Changelog:
- Conserta a o nome da tabela na query defaul de `municipios` para `municipio` devido padronização de dados no datalake
- Modificação para uso de Path explicito, utilizando o Path do arquivo que está sendo executado