### PR TITLE
[infra] Melhora output das funções list_* e get_* na API do Python

### DIFF
--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -293,38 +293,12 @@ def _print_output(df):
     #        ) if len(lista) else final)
 
 
-def _handle_output(output_type, df, id_col):
-    """Handles datasets and tables listing outputs based on user's choice.
-    Either prints it to the screen or returns it as a `list` object.
-
-    Args:
-        output_type (str): output type, either "print"  or "list"
-        df (pd.DataFrame): table containing datasets metadata
-        id_col (str): name of column with id's data
-    """
-
-
-
-    if output_type == "print":
-        _print_output(df)
-
-    elif output_type == "list":
-        return df[id_col].to_list()
-
-    else:
-        raise BaseDosDadosException(
-            "You must set the output_type to either \"print\" or \"list\"."
-        )
-    
-    return None
-
-
 def list_datasets(
     query_project_id="basedosdados",
-    output_type="print",
     filter_by=None,
     with_description=False,
     from_file=False,
+    verbose=True
 ):
     """Fetch the dataset_id of datasets available at query_project_id. Prints information on
     screen or returns it as a list..
@@ -367,20 +341,19 @@ def list_datasets(
             for dataset in datasets["dataset_id"]
         ]
 
-    return _handle_output(
-        output_type=output_type,
-        df=datasets,
-        id_col="dataset_id"
-    )
+    if verbose:
+        _print_output(datasets)
+    
+    return datasets["dataset_id"].to_list()
 
 
 def list_dataset_tables(
     dataset_id,
     query_project_id="basedosdados",
-    output_type="print",
     from_file=False,
     filter_by=None,
     with_description=False,
+    verbose=True,
 ):
     """Fetch table_id for tables available at the specified dataset_id. Prints the information
     on screen or returns it as a list.
@@ -426,12 +399,11 @@ def list_dataset_tables(
             _get_header(client.get_table(f"{dataset_id}.{table}").description)
             for table in tables["table_id"]
         ]
+    
+    if verbose:
+        _print_output(tables)
 
-    return _handle_output(
-        output_type=output_type,
-        df=tables,
-        id_col="table_id"
-    )
+    return tables["table_id"].to_list()
 
 
 def get_dataset_description(

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -295,16 +295,19 @@ def _print_output(df):
 
 def list_datasets(
     query_project_id="basedosdados",
+    output_type="print",
     filter_by=None,
     with_description=False,
     from_file=False,
 ):
     """Fetch the dataset_id of datasets available at query_project_id. Prints information on
-    screen.
+    screen or returns it as a list..
 
     Args:
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
+        output_type (str): Optional.
+            If set to "print", information is printed to the screen. If set to "list", a list object is returned.     
         filter_by (str): Optional
             String to be matched in dataset_id.
         with_description (bool): Optional
@@ -338,7 +341,16 @@ def list_datasets(
             for dataset in datasets["dataset_id"]
         ]
 
-    _print_output(datasets)
+    if output_type == "print":
+        _print_output(datasets)
+
+    elif output_type == "list":
+        return datasets["dataset_id"].to_list()
+
+    else:
+        raise BaseDosDadosException(
+            "You must set the output_type to either \"print\" or \"list\"."
+        )
 
     return None
 

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -293,6 +293,32 @@ def _print_output(df):
     #        ) if len(lista) else final)
 
 
+def _handle_output(output_type, df, id_col):
+    """Handles datasets and tables listing outputs based on user's choice.
+    Either prints it to the screen or returns it as a `list` object.
+
+    Args:
+        output_type (str): output type, either "print"  or "list"
+        df (pd.DataFrame): table containing datasets metadata
+        id_col (str): name of column with id's data
+    """
+
+
+
+    if output_type == "print":
+        _print_output(df)
+
+    elif output_type == "list":
+        return df[id_col].to_list()
+
+    else:
+        raise BaseDosDadosException(
+            "You must set the output_type to either \"print\" or \"list\"."
+        )
+    
+    return None
+
+
 def list_datasets(
     query_project_id="basedosdados",
     output_type="print",
@@ -341,18 +367,11 @@ def list_datasets(
             for dataset in datasets["dataset_id"]
         ]
 
-    if output_type == "print":
-        _print_output(datasets)
-
-    elif output_type == "list":
-        return datasets["dataset_id"].to_list()
-
-    else:
-        raise BaseDosDadosException(
-            "You must set the output_type to either \"print\" or \"list\"."
-        )
-
-    return None
+    return _handle_output(
+        output_type=output_type,
+        df=datasets,
+        id_col="dataset_id"
+    )
 
 
 def list_dataset_tables(
@@ -408,18 +427,11 @@ def list_dataset_tables(
             for table in tables["table_id"]
         ]
 
-    if output_type == "print":
-        _print_output(tables)
-
-    elif output_type == "list":
-        return tables["table_id"].to_list()
-
-    else:
-        raise BaseDosDadosException(
-            "You must set the output_type to either \"print\" or \"list\"."
-        )
-
-    return None
+    return _handle_output(
+        output_type=output_type,
+        df=tables,
+        id_col="table_id"
+    )
 
 
 def get_dataset_description(

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -1,3 +1,4 @@
+from google.cloud.bigquery import dataset
 import pandas_gbq
 from pathlib import Path
 import pydata_google_auth
@@ -293,24 +294,40 @@ def _print_output(df):
     #        ) if len(lista) else final)
 
 
-def _handle_output(verbose, df, id_col):
+def _handle_output(verbose, output_type, df, col_name=None):
     """Handles datasets and tables listing outputs based on user's choice.
     Either prints it to the screen or returns it as a `list` object.
     Args:
         verbose (bool): amount of verbosity
-        df (pd.DataFrame): table containing datasets metadata
-        id_col (str): name of column with id's data
+        output_type (str): type of output
+        df (pd.DataFrame, bigquery.Dataset or bigquery.Table): table containing datasets metadata
+        col_name (str): name of column with id's data
     """
 
-    if verbose:
+    df_is_dataframe = type(df) == pd.DataFrame
+    df_is_bq_dataset_or_table = (
+        (type(df) == bigquery.Dataset) or (type(df) == bigquery.Table)
+    )
+
+    if verbose == True and df_is_dataframe:
         _print_output(df)
 
+    elif verbose == True and df_is_bq_dataset_or_table:
+        print(df.description)
+
     elif verbose == False:
-        return df[id_col].to_list()
+        if output_type == "list":
+            return df[col_name].to_list()
+        elif output_type == "str":
+            return df.description
+        elif output_type == "records":
+            return df.to_dict("records")
+        else:
+            raise ValueError("`output_type` argument must be set to \"list\", \"str\" or \"records\".")
 
     else:
-        raise BaseDosDadosException(
-            "You must set the `verbose` argument to either True or False."
+        raise TypeError(
+            "`verbose` argument must be of `bool` type."
         )
 
     return None
@@ -367,8 +384,9 @@ def list_datasets(
 
     return _handle_output(
         verbose=verbose,
+        output_type="list",
         df=datasets,
-        id_col="dataset_id"
+        col_name="dataset_id"
     )
 
 
@@ -427,13 +445,17 @@ def list_dataset_tables(
     
     return _handle_output(
         verbose=verbose,
+        output_type="list",
         df=tables,
-        id_col="table_id"
+        col_name="table_id"
     )
 
 
 def get_dataset_description(
-    dataset_id=None, query_project_id="basedosdados", from_file=False
+    dataset_id=None,
+    query_project_id="basedosdados",
+    from_file=False,
+    verbose=True
 ):
     """Prints the full dataset description.
 
@@ -442,6 +464,8 @@ def get_dataset_description(
             Dataset id available in basedosdados.
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, data is returned as a `str`.
     """
 
     client = bigquery.Client(
@@ -450,9 +474,11 @@ def get_dataset_description(
 
     dataset = client.get_dataset(dataset_id)
 
-    print(dataset.description)
-
-    return None
+    return _handle_output(
+        verbose=verbose,
+        output_type="str",
+        df=dataset
+    )
 
 
 def get_table_description(
@@ -460,6 +486,7 @@ def get_table_description(
     table_id=None,
     query_project_id="basedosdados",
     from_file=False,
+    verbose=True
 ):
     """Prints the full table description.
 
@@ -471,6 +498,8 @@ def get_table_description(
             It should always come with dataset_id.
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, data is returned as a `str`.
     """
 
     client = bigquery.Client(
@@ -479,9 +508,11 @@ def get_table_description(
 
     table = client.get_table(f"{dataset_id}.{table_id}")
 
-    print(table.description)
-
-    return None
+    return _handle_output(
+        verbose=verbose,
+        output_type="str",
+        df=table
+    )
 
 
 def get_table_columns(
@@ -489,6 +520,7 @@ def get_table_columns(
     table_id=None,
     query_project_id="basedosdados",
     from_file=False,
+    verbose=True
 ):
 
     """Fetch the names, types and descriptions for the columns in the specified table. Prints
@@ -502,6 +534,8 @@ def get_table_columns(
             It should always come with dataset_id.
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, data is returned as a `list` of `dict`s.
     Example:
         get_table_columns(
         dataset_id='br_ibge_censo2010',
@@ -521,9 +555,11 @@ def get_table_columns(
 
     description = pd.DataFrame(columns, columns=["name", "field_type", "description"])
 
-    _print_output(description)
-
-    return None
+    return _handle_output(
+        verbose=verbose,
+        output_type="records",
+        df=description
+    )
 
 
 def get_table_size(
@@ -532,6 +568,7 @@ def get_table_size(
     billing_project_id,
     query_project_id="basedosdados",
     from_file=False,
+    verbose=True
 ):
     """Use a query to get the number of rows and size (in Mb) of a table query
     from BigQuery. Prints information on screen in markdown friendly format.
@@ -548,6 +585,8 @@ def get_table_size(
             Which project the table lives. You can change this you want to query different projects.
         billing_project_id (str): Optional.
             Project that will be billed. Find your Project ID here https://console.cloud.google.com/projectselector2/home/dashboard
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, data is returned as a `list` of `dict`s.
     Example:
         get_table_size(
         dataset_id='br_ibge_censo2010',
@@ -579,6 +618,8 @@ def get_table_size(
         ]
     )
 
-    _print_output(table_data)
-
-    return None
+    return _handle_output(
+        verbose=verbose,
+        output_type="records",
+        df=table_data
+    )

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -293,6 +293,29 @@ def _print_output(df):
     #        ) if len(lista) else final)
 
 
+def _handle_output(verbose, df, id_col):
+    """Handles datasets and tables listing outputs based on user's choice.
+    Either prints it to the screen or returns it as a `list` object.
+    Args:
+        verbose (bool): amount of verbosity
+        df (pd.DataFrame): table containing datasets metadata
+        id_col (str): name of column with id's data
+    """
+
+    if verbose:
+        _print_output(df)
+
+    elif verbose == False:
+        return df[id_col].to_list()
+
+    else:
+        raise BaseDosDadosException(
+            "You must set the `verbose` argument to either True or False."
+        )
+
+    return None
+
+
 def list_datasets(
     query_project_id="basedosdados",
     filter_by=None,
@@ -301,17 +324,18 @@ def list_datasets(
     verbose=True
 ):
     """Fetch the dataset_id of datasets available at query_project_id. Prints information on
-    screen or returns it as a list..
+    screen or returns it as a list.
 
     Args:
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
-        output_type (str): Optional.
-            If set to "print", information is printed to the screen. If set to "list", a list object is returned.     
         filter_by (str): Optional
             String to be matched in dataset_id.
         with_description (bool): Optional
             If True, fetch short dataset description for each dataset.
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, a list object is returned.
+
 
     Example:
         list_datasets(
@@ -341,10 +365,11 @@ def list_datasets(
             for dataset in datasets["dataset_id"]
         ]
 
-    if verbose:
-        _print_output(datasets)
-    
-    return datasets["dataset_id"].to_list()
+    return _handle_output(
+        verbose=verbose,
+        df=datasets,
+        id_col="dataset_id"
+    )
 
 
 def list_dataset_tables(
@@ -363,12 +388,12 @@ def list_dataset_tables(
             Dataset id available in basedosdados.
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
-        output_type (str): Optional.
-            If set to "print", information is printed to the screen. If set to "list", a list object is returned.
         filter_by (str): Optional
             String to be matched in the table_id.
         with_description (bool): Optional
              If True, fetch short table descriptions for each table that match the search criteria.
+        verbose (bool): Optional.
+            If set to True, information is printed to the screen. If set to False, a list object is returned.
 
     Example:
         list_dataset_tables(
@@ -400,10 +425,11 @@ def list_dataset_tables(
             for table in tables["table_id"]
         ]
     
-    if verbose:
-        _print_output(tables)
-
-    return tables["table_id"].to_list()
+    return _handle_output(
+        verbose=verbose,
+        df=tables,
+        id_col="table_id"
+    )
 
 
 def get_dataset_description(

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -358,18 +358,21 @@ def list_datasets(
 def list_dataset_tables(
     dataset_id,
     query_project_id="basedosdados",
+    output_type="print",
     from_file=False,
     filter_by=None,
     with_description=False,
 ):
     """Fetch table_id for tables available at the specified dataset_id. Prints the information
-    on screen.
+    on screen or returns it as a list.
 
     Args:
         dataset_id (str): Optional.
             Dataset id available in basedosdados.
         query_project_id (str): Optional.
             Which project the table lives. You can change this you want to query different projects.
+        output_type (str): Optional.
+            If set to "print", information is printed to the screen. If set to "list", a list object is returned.
         filter_by (str): Optional
             String to be matched in the table_id.
         with_description (bool): Optional
@@ -405,7 +408,16 @@ def list_dataset_tables(
             for table in tables["table_id"]
         ]
 
-    _print_output(tables)
+    if output_type == "print":
+        _print_output(tables)
+
+    elif output_type == "list":
+        return tables["table_id"].to_list()
+
+    else:
+        raise BaseDosDadosException(
+            "You must set the output_type to either \"print\" or \"list\"."
+        )
 
     return None
 

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -157,7 +157,7 @@ def test_list_datasets_all_descriptions(capsys):
 
 def test_list_datasets_list_output():
 
-    list_output = list_datasets(output_type="list", from_file=True)
+    list_output = list_datasets(from_file=True, verbose=False)
     assert type(list_output) == list
     assert len(list_output) > 0
 
@@ -195,8 +195,8 @@ def test_list_dataset_tables_list_output():
 
     list_output = list_dataset_tables(
         dataset_id="br_ibge_censo_demografico",
-        output_type="list",
-        from_file=True
+        from_file=True,
+        verbose=False
     )
     assert type(list_output) == list
     assert len(list_output) > 0

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -191,6 +191,17 @@ def test_list_dataset_tables_all_descriptions(capsys):
     assert len(out) > 0
 
 
+def test_list_dataset_tables_list_output():
+
+    list_output = list_dataset_tables(
+        dataset_id="br_ibge_censo_demografico",
+        output_type="list",
+        from_file=True
+    )
+    assert type(list_output) == list
+    assert len(list_output) > 0
+
+
 def test_get_dataset_description(capsys):
 
     get_dataset_description("br_ibge_censo_demografico", from_file=True)

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -155,7 +155,7 @@ def test_list_datasets_all_descriptions(capsys):
     assert len(out) > 0
 
 
-def test_list_datasets_list_output():
+def test_list_datasets_verbose_false():
 
     list_output = list_datasets(from_file=True, verbose=False)
     assert type(list_output) == list
@@ -191,7 +191,7 @@ def test_list_dataset_tables_all_descriptions(capsys):
     assert len(out) > 0
 
 
-def test_list_dataset_tables_list_output():
+def test_list_dataset_tables_verbose_false():
 
     list_output = list_dataset_tables(
         dataset_id="br_ibge_censo_demografico",

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -157,9 +157,9 @@ def test_list_datasets_all_descriptions(capsys):
 
 def test_list_datasets_verbose_false():
 
-    list_output = list_datasets(from_file=True, verbose=False)
-    assert type(list_output) == list
-    assert len(list_output) > 0
+    out = list_datasets(from_file=True, verbose=False)
+    assert type(out) == list
+    assert len(out) > 0
 
 
 def test_list_dataset_tables(capsys):
@@ -193,13 +193,13 @@ def test_list_dataset_tables_all_descriptions(capsys):
 
 def test_list_dataset_tables_verbose_false():
 
-    list_output = list_dataset_tables(
+    out = list_dataset_tables(
         dataset_id="br_ibge_censo_demografico",
         from_file=True,
         verbose=False
     )
-    assert type(list_output) == list
-    assert len(list_output) > 0
+    assert type(out) == list
+    assert len(out) > 0
 
 
 def test_get_dataset_description(capsys):
@@ -209,11 +209,32 @@ def test_get_dataset_description(capsys):
     assert len(out) > 0
 
 
+def test_get_dataset_description_verbose_false():
+    out = get_dataset_description(
+        "br_ibge_censo_demografico",
+        from_file=True,
+        verbose=False
+    )
+    assert type(out) == str
+    assert len(out) > 0
+
+
 def test_get_table_description(capsys):
     get_table_description(
         "br_ibge_censo_demografico", "setor_censitario_basico_2010", from_file=True
     )
     out, err = capsys.readouterr()  # Capture prints
+    assert len(out) > 0
+
+
+def test_get_table_description_verbose_false():
+    out = get_table_description(
+        dataset_id="br_ibge_censo_demografico",
+        table_id="setor_censitario_basico_2010",
+        from_file=True,
+        verbose=False
+    )
+    assert type(out) == str
     assert len(out) > 0
 
 
@@ -229,6 +250,17 @@ def test_get_table_columns(capsys):
     assert "description" in out
 
 
+def test_get_table_columns_verbose_false():
+    out = get_table_columns(
+        dataset_id="br_ibge_censo_demografico",
+        table_id="setor_censitario_basico_2010",
+        from_file=True,
+        verbose=False
+    )
+    assert type(out) == list
+    assert len(out) > 0
+
+
 def test_get_table_size(capsys):
     get_table_size(
         dataset_id="br_ibge_censo_demografico",
@@ -239,3 +271,14 @@ def test_get_table_size(capsys):
     out, err = capsys.readouterr()
     assert "num_rows" in out
     assert "size_mb" in out
+
+
+def test_get_table_size_verbose_false():
+    out = get_table_size(
+        dataset_id="br_ibge_censo_demografico",
+        table_id="setor_censitario_basico_2010",
+        billing_project_id=TEST_PROJECT_ID,
+        from_file=True
+    )
+    assert type(out) == list
+    assert len(out) > 0

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -155,6 +155,13 @@ def test_list_datasets_all_descriptions(capsys):
     assert len(out) > 0
 
 
+def test_list_datasets_list_output():
+
+    list_output = list_datasets(output_type="list", from_file=True)
+    assert type(list_output) == list
+    assert len(list_output) > 0
+
+
 def test_list_dataset_tables(capsys):
 
     list_dataset_tables(dataset_id="br_ibge_censo_demografico", from_file=True)

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -278,7 +278,8 @@ def test_get_table_size_verbose_false():
         dataset_id="br_ibge_censo_demografico",
         table_id="setor_censitario_basico_2010",
         billing_project_id=TEST_PROJECT_ID,
-        from_file=True
+        from_file=True,
+        verbose=False
     )
     assert type(out) == list
     assert len(out) > 0

--- a/python-package/tests/test_storage.py
+++ b/python-package/tests/test_storage.py
@@ -8,7 +8,6 @@ from basedosdados import Storage
 DATASET_ID = "pytest"
 TABLE_ID = "pytest"
 SAVEPATH = Path(__file__).parent / "tmp_bases"
-
 TABLE_FILES = ["publish.sql", "table_config.yaml"]
 
 


### PR DESCRIPTION
# Issues relacionadas
* #522 

# Descrição breve
1. Adiciona parâmetro `output_type` às funções `list_datasets` e `list_dataset_tables` da API do Python. O `output_type` admite apenas as opções `"list"` ou `"print"`, de forma excludente, sendo `"print"` o valor padrão.
2. Adiciona teste simples para cada uma das duas funções, para o caso do `output_type="list"`, já que a opção `"print"` já está coberta pelos testes atuais.
3. Atualiza docstrings explicando o novo parâmetro.