### PR TITLE
[infra] Adiciona testes e corrige o traceback da função `download`

### DIFF
--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -1,4 +1,3 @@
-from google.api_core.exceptions import NotFound
 from google.cloud.bigquery import dataset
 import pandas_gbq
 from pathlib import Path

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -183,7 +183,7 @@ def read_sql(query, billing_project_id=None, from_file=False, reauth=False):
             )
             raise BaseDosDadosException(msg) from e
         
-        elif re.match("Reason: 400 POST .* Invalid project ID", str(e)):
+        elif re.match("Reason: 400 POST .* [Pp]roject[ ]*I[Dd]", str(e)):
             msg = (
                 "\nYou are using an invalid `billing_project_id`.\nMake sure "
                 "you set it to the Project ID available in your Google Cloud"
@@ -206,8 +206,12 @@ def read_sql(query, billing_project_id=None, from_file=False, reauth=False):
         )
         raise BaseDosDadosException(msg) from e
 
-    except ValueError as e:
-        if "Could not determine project ID" in str(e):
+    except (OSError, ValueError) as e:
+        exc_from_no_billing_id = (
+            "Could not determine project ID" in str(e) or \
+            "reading from stdin while output is captured" in str(e)
+        )
+        if exc_from_no_billing_id:
             msg = (
                 "\nWe are not sure which Google Cloud project should be billed.\n"
                 "First, you should make sure that you have a Google Cloud project.\n"

--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -2,9 +2,11 @@ from google.cloud.bigquery import dataset
 import pandas_gbq
 from pathlib import Path
 import pydata_google_auth
+from pydata_google_auth.exceptions import PyDataCredentialsError
 from google.cloud import bigquery
 from google.cloud import bigquery_storage_v1
 from functools import partialmethod
+import re
 import pandas as pd
 from basedosdados.upload.base import Base
 from functools import partialmethod
@@ -164,38 +166,67 @@ def read_sql(query, billing_project_id=None, from_file=False, reauth=False):
     except GenericGBQException as e:
         if "Reason: 403" in str(e):
             msg = (
-                "\nYou still don't have a Google Cloud Project.\n"
-                "Set one up following these steps: \n"
+                "\nAre you sure you are using the right `billing_project_id`?"
+                "\nYou must use the Project ID available in your Google Cloud"
+                " console home page at https://console.cloud.google.com/home/dashboard"
+                "\nIf you still don't have a Google Cloud Project, you have to "
+                "create one.\n"
+                "You can set one up by following these steps: \n"
                 "1. Go to this link https://console.cloud.google.com/projectselector2/home/dashboard\n"
                 "2. Agree with Terms of Service if asked\n"
                 "3. Click in Create Project\n"
                 "4. Put a cool name in your project\n"
                 "5. Hit create\n"
                 "6. Rerun this command with the flag `reauth=True`. \n"
-                "   Like `read_table('br_ibge_pib', 'municipios', reauth=True)`"
+                "   Like `read_table('br_ibge_pib', 'municipios', "
+                "billing_project_id=<YOUR_PROJECT_ID>, reauth=True)`"
+            )
+            raise BaseDosDadosException(msg) from e
+        
+        elif re.match("Reason: 400 POST .* Invalid project ID", str(e)):
+            msg = (
+                "\nYou are using an invalid `billing_project_id`.\nMake sure "
+                "you set it to the Project ID available in your Google Cloud"
+                " console home page at https://console.cloud.google.com/home/dashboard"
+            )
+            raise BaseDosDadosException(msg) from e
+
+        raise
+
+    except PyDataCredentialsError as e:
+        msg = (
+            "\nAre you sure you did the authorization process correctly?\n"
+            "If you were given the option to enter an authorization code, "
+            "please try again and make sure you are entering the right one."
+            "\nYou can try again by rerunning this command with the flag "
+            "`reauth=True`. \n\tLike `read_table('br_ibge_pib', 'municipios',"
+            " billing_project_id=<YOUR_PROJECT_ID>, reauth=True)`"
+            "\nThen you can click at the provided link and get the right "
+            "authorization code."
+        )
+        raise BaseDosDadosException(msg) from e
+
+    except ValueError as e:
+        if "Could not determine project ID" in str(e):
+            msg = (
+                "\nWe are not sure which Google Cloud project should be billed.\n"
+                "First, you should make sure that you have a Google Cloud project.\n"
+                "If you don't have one, set one up following these steps: \n"
+                "\t1. Go to this link https://console.cloud.google.com/projectselector2/home/dashboard\n"
+                "\t2. Agree with Terms of Service if asked\n"
+                "\t3. Click in Create Project\n"
+                "\t4. Put a cool name in your project\n"
+                "\t5. Hit create\n"
+                "\n"
+                "Copy the Project ID, (notice that it is not the Project Name)\n"
+                "Now, you have two options:\n"
+                "1. Add an argument to your function poiting to the billing project id.\n"
+                "   Like `bd.read_table('br_ibge_pib', 'municipios', billing_project_id=<YOUR_PROJECT_ID>)`\n"
+                "2. You can set a project_id in the environment by running the following command in your terminal: `gcloud config set project <YOUR_PROJECT_ID>`.\n"
+                "   Bear in mind that you need `gcloud` installed."
             )
             raise BaseDosDadosException(msg) from e
         raise
-
-    except (OSError, ValueError) as e:
-        msg = (
-            "\nWe are not sure which Google Cloud project should be billed.\n"
-            "First, you should make sure that you have a Google Cloud project.\n"
-            "If you don't have one, set one up following these steps: \n"
-            "\t1. Go to this link https://console.cloud.google.com/projectselector2/home/dashboard\n"
-            "\t2. Agree with Terms of Service if asked\n"
-            "\t3. Click in Create Project\n"
-            "\t4. Put a cool name in your project\n"
-            "\t5. Hit create\n"
-            "\n"
-            "Copy the Project ID, (notice that it is not the Project Name)\n"
-            "Now, you have two options:\n"
-            "1. Add an argument to your function poiting to the billing project id.\n"
-            "   Like `bd.read_table('br_ibge_pib', 'municipios', billing_project_id=<YOUR_PROJECT_ID>)`\n"
-            "2. You can set a project_id in the environment by running the following command in your terminal: `gcloud config set project <YOUR_PROJECT_ID>`.\n"
-            "   Bear in mind that you need `gcloud` installed."
-        )
-        raise BaseDosDadosException(msg) from e
 
 
 def read_table(

--- a/python-package/basedosdados/exceptions.py
+++ b/python-package/basedosdados/exceptions.py
@@ -1,0 +1,75 @@
+class BaseDosDadosException(Exception):
+    """Exclusive Exception from Base dos Dados"""
+
+
+class BaseDosDadosAccessDeniedException(BaseDosDadosException):
+    """Exception raised if the user provides a wrong GCP project ID."""
+    def __init__(self):
+        self.message = (
+            "\nAre you sure you are using the right `billing_project_id`?"
+            "\nYou must use the Project ID available in your Google Cloud"
+            " console home page at https://console.cloud.google.com/home/dashboard"
+            "\nIf you still don't have a Google Cloud Project, you have to "
+            "create one.\n"
+            "You can set one up by following these steps: \n"
+            "1. Go to this link https://console.cloud.google.com/projectselector2/home/dashboard\n"
+            "2. Agree with Terms of Service if asked\n"
+            "3. Click in Create Project\n"
+            "4. Put a cool name in your project\n"
+            "5. Hit create\n"
+            "6. Rerun this command with the flag `reauth=True`. \n"
+            "   Like `read_table('br_ibge_pib', 'municipios', "
+            "billing_project_id=<YOUR_PROJECT_ID>, reauth=True)`"
+        )
+        super().__init__(self.message)
+
+
+class BaseDosDadosInvalidProjectIDException(BaseDosDadosException):
+    """Exception raised if the user provides an invalid GCP project ID."""
+    def __init__(self):
+        self.message = (
+            "\nYou are using an invalid `billing_project_id`.\nMake sure "
+            "you set it to the Project ID available in your Google Cloud"
+            " console home page at https://console.cloud.google.com/home/dashboard"
+        )
+        super().__init__(self.message)
+
+
+class BaseDosDadosNoBillingProjectIDException(BaseDosDadosException):
+    """Exception raised if the user provides no GCP billing project ID."""
+    def __init__(self):
+        self.message = (
+            "\nWe are not sure which Google Cloud project should be billed.\n"
+            "First, you should make sure that you have a Google Cloud project.\n"
+            "If you don't have one, set one up following these steps: \n"
+            "\t1. Go to this link https://console.cloud.google.com/projectselector2/home/dashboard\n"
+            "\t2. Agree with Terms of Service if asked\n"
+            "\t3. Click in Create Project\n"
+            "\t4. Put a cool name in your project\n"
+            "\t5. Hit create\n"
+            "\n"
+            "Copy the Project ID, (notice that it is not the Project Name)\n"
+            "Now, you have two options:\n"
+            "1. Add an argument to your function poiting to the billing project id.\n"
+            "   Like `bd.read_table('br_ibge_pib', 'municipios', billing_project_id=<YOUR_PROJECT_ID>)`\n"
+            "2. You can set a project_id in the environment by running the following command in your terminal: `gcloud config set project <YOUR_PROJECT_ID>`.\n"
+            "   Bear in mind that you need `gcloud` installed."
+        )
+        super().__init__(self.message)
+
+
+class BaseDosDadosAuthorizationException(BaseDosDadosException):
+    """Exception raised if the user doesn't complete the authorization
+    process correctly."""
+    def __init__(self):
+        self.message = (
+            "\nAre you sure you did the authorization process correctly?\n"
+            "If you were given the option to enter an authorization code, "
+            "please try again and make sure you are entering the right one."
+            "\nYou can try again by rerunning this command with the flag "
+            "`reauth=True`. \n\tLike `read_table('br_ibge_pib', 'municipios',"
+            " billing_project_id=<YOUR_PROJECT_ID>, reauth=True)`"
+            "\nThen you can click at the provided link and get the right "
+            "authorization code."
+        )
+        super().__init__(self.message)

--- a/python-package/basedosdados/upload/table.py
+++ b/python-package/basedosdados/upload/table.py
@@ -17,7 +17,7 @@ from basedosdados.upload.base import Base
 from basedosdados.upload.storage import Storage
 from basedosdados.upload.dataset import Dataset
 from basedosdados.upload.datatypes import Datatype
-from basedosdados.validation.exceptions import BaseDosDadosException
+from basedosdados.exceptions import BaseDosDadosException
 
 
 class Table(Base):

--- a/python-package/basedosdados/validation/exceptions.py
+++ b/python-package/basedosdados/validation/exceptions.py
@@ -1,2 +1,0 @@
-class BaseDosDadosException(Exception):
-    """Exclusive Exception from Base dos Dados"""

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -60,6 +60,8 @@ def test_download_invalid_billing_project_id():
             SAVEFILE,
             query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
             billing_project_id="inexistent_project_id",
+            index=False,
+            from_file=True
         )
     
     with pytest.raises(GenericGBQException, match=pattern):
@@ -68,7 +70,9 @@ def test_download_invalid_billing_project_id():
             dataset_id="br_ibge_pib",
             table_id="municipio",
             limit=10,
-            billing_project_id="inexistent_project_id"
+            billing_project_id="inexistent_project_id",
+            index=False,
+            from_file=True
         )
 
 
@@ -129,6 +133,20 @@ def test_download_by_query_inexistent_table():
         )
     
     assert "Reason: 404 Not found: Table" in str(excinfo.value)
+
+
+def test_download_by_query_syntax_error():
+
+        with pytest.raises(GenericGBQException) as excinfo:
+            download(
+                SAVEFILE,
+                query="invalid_statement * from `basedosdados.br_ibge_pib.municipio` limit 10",
+                billing_project_id=TEST_PROJECT_ID,
+                index=False,
+                from_file=True
+            )
+        
+        assert "Reason: 400 Syntax error" in str(excinfo.value)
 
 
 def test_download_by_table():

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -120,9 +120,9 @@ def test_read_sql_no_billing_project_id():
 
 def test_read_sql_invalid_billing_project_id():
     
-    pattern = r"Reason: 400 POST .* Invalid project ID"
+    pattern = r"You are using an invalid `billing_project_id`"
     
-    with pytest.raises(GenericGBQException, match=pattern):
+    with pytest.raises(BaseDosDadosException, match=pattern):
         read_sql(
             query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
             billing_project_id="inexistent_project_id",
@@ -134,12 +134,12 @@ def test_read_sql_inexistent_project():
 
     with pytest.raises(GenericGBQException) as excinfo:
         read_sql(
-            query="select * from `inexistent.br_ibge_pib.municipio` limit 10",
+            query="select * from `asedosdados.br_ibge_pib.municipio` limit 10",
             billing_project_id=TEST_PROJECT_ID,
             from_file=True
         )
     
-    assert "Reason: 400 The project inexistent" in str(excinfo.value)
+    assert "Reason: 404 Not found: Project" in str(excinfo.value)
 
 
 def test_read_sql_inexistent_dataset():

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -76,10 +76,6 @@ def test_download_invalid_billing_project_id():
         )
 
 
-def test_download_access_denied():
-    pass
-
-
 def test_download_by_query():
 
     download(

--- a/python-package/tests/test_download.py
+++ b/python-package/tests/test_download.py
@@ -16,7 +16,10 @@ from basedosdados import (
     get_table_columns,
     get_table_size,
 )
-from basedosdados.validation.exceptions import BaseDosDadosException
+from basedosdados.exceptions import (
+    BaseDosDadosException, BaseDosDadosNoBillingProjectIDException,
+    BaseDosDadosInvalidProjectIDException
+)
 
 
 TEST_PROJECT_ID = "basedosdados-dev"
@@ -107,7 +110,7 @@ def test_read_sql():
 
 def test_read_sql_no_billing_project_id():
 
-    with pytest.raises(BaseDosDadosException) as excinfo:
+    with pytest.raises(BaseDosDadosNoBillingProjectIDException) as excinfo:
         read_sql(
             query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
         )
@@ -122,7 +125,7 @@ def test_read_sql_invalid_billing_project_id():
     
     pattern = r"You are using an invalid `billing_project_id`"
     
-    with pytest.raises(BaseDosDadosException, match=pattern):
+    with pytest.raises(BaseDosDadosInvalidProjectIDException, match=pattern):
         read_sql(
             query="select * from `basedosdados.br_ibge_pib.municipio` limit 10",
             billing_project_id="inexistent_project_id",

--- a/python-package/tests/test_table.py
+++ b/python-package/tests/test_table.py
@@ -5,7 +5,7 @@ import shutil
 from google.api_core.exceptions import NotFound
 
 from basedosdados import Dataset, Table, Storage
-from basedosdados.validation.exceptions import BaseDosDadosException
+from basedosdados.exceptions import BaseDosDadosException
 
 DATASET_ID = "pytest"
 TABLE_ID = "pytest"


### PR DESCRIPTION
# Issues e PRs relacionados
*  PR #580 
* Issue #519 

# Descrição breve
Este PR corrige o traceback das funções `download`, `read_sql` e `read_table` e adiciona testes que verificam se cada erro específico está associado ao traceback correto. Como sugerido por @JoaoCarabetta [aqui](https://github.com/basedosdados/mais/issues/519#issuecomment-882939665), dei preferência às exceções do `pandas-gbq`.

## Modificações em `download.py`
* Corrige ordem do bloco `try`/`except` em `read_sql`, colocando as exceções mais específicas primeiro. As mais genéricas estavam no começo, impedindo que as mais específicas aparecessem. 

## Modificações em `test_download.py`
* Isola teste do caso da não especificação de `billing_project_id`
* Adiciona testes para os seguintes erros:
  * `billing_project_id` especificado, porém inválido
  * query inválida: projeto inexistente
  * query inválida: dataset inexistente (`test_download_by_query_*` e `test_download_by_table_*`)
  * query inválida: tabela inexistente (`test_download_by_query_*` e `test_download_by_table_*`)
  * query inválida: erro de sintaxe de SQL

# Possíveis alterações para este PR
* Fazer um teste para o caso de `billing_project_id` cujo acesso é negado. Não sei qual ID usar para esse caso. Alguém tem uma ideia?
* Melhorar exceções em `read_sql`: atualmente o caso do acesso negado aponta para uma `BaseDosDadosException` que indica que o usuário ainda não tem um projeto. Será que isso faz sentido ou deveriamos, aqui, dar preferência ao erro do `pandas-gbq`?