### PR TITLE
[infra] adds upload header to storage

### DIFF
--- a/.github/workflows/table-approve/table_approve.py
+++ b/.github/workflows/table-approve/table_approve.py
@@ -211,6 +211,15 @@ def push_table_to_bq(
     # updates the dataset description
     Dataset(dataset_id).update("prod")
 
+    ### save table header in storage
+    query = f"""
+    SELECT * FROM `basedosdados.{dataset_id}.{table_id}` LIMIT 5
+    """
+    df = bd.read_sql(query, billing_project_id="basedosdados-dev", from_file=True)
+    df.to_csv("header.csv", index=False, encoding="utf=8")
+    st = bd.Storage(dataset_id=dataset_id, table_id=dataset_id)
+    st.upload("header.csv", mode="header")
+
 
 def pretty_log(dataset_id, table_id, source_bucket_name):
     source_len = len(source_bucket_name)

--- a/python-package/basedosdados/upload/base.py
+++ b/python-package/basedosdados/upload/base.py
@@ -320,7 +320,7 @@ class Base:
         ).render(**kargs)
 
     def _check_mode(self, mode):
-        ACCEPTED_MODES = ["all", "staging", "prod", "raw"]
+        ACCEPTED_MODES = ["all", "staging", "prod", "raw", "header", "auxiliary_files"]
         if mode in ACCEPTED_MODES:
             return True
         else:


### PR DESCRIPTION
### Motivação
 - Adicionar o header das tabelas no site

### Breve descrição das alterações
- No `base.py`Adicionei mais duas opções de mode, `header`e `auxiliary_files, para fazer upload para o storage
- No `table_approve.py` adicionei o download das 5 primeiras linhas da tabela criada no bigquery e upload para o storage na pasta header

### Pendências
- Tem que lançar uma versão nova do pacote e mudar no `table-approve.yml`