### PR TITLE
[infra] Conserta dependência do `mkdocs` no `requirements-dev.txt`

### DIFF
--- a/python-package/requirements-dev.txt
+++ b/python-package/requirements-dev.txt
@@ -12,6 +12,7 @@ pytest
 ipykernel
 jupyter
 poetry
+importlib_metadata>3.10
 mkdocs
 mkdocs-material
 flake8


### PR DESCRIPTION
# Descrição
Atualiza dependências do ambiente dev de Python usado pela Action `build-docs`, resolvendo o issue #974.  