### PR TITLE
[infra] Conserta passo de publicação dos metadados na Action `table-approve`

### DIFF
--- a/.github/workflows/table-approve/table_approve.py
+++ b/.github/workflows/table-approve/table_approve.py
@@ -315,6 +315,14 @@ def table_approve():
             md = Metadata(dataset_id=dataset_id, table_id=table_id)
             md.validate()
             tprint(f"SUCESS VALIDATE {dataset_id}.{table_id}")
+            
+            if not md.dataset_metadata_obj.exists_in_ckan():
+                # validate and create dataset metadata in ckan first
+                md.dataset_metadata_obj.validate()
+                tprint(f"SUCESS VALIDATE {dataset_id}")
+                md.dataset_metadata_obj.publish()
+                tprint(f"SUCESS PUBLISH {dataset_id}")
+
             md.publish(if_exists="replace")
             tprint(f"SUCESS PUBLISHED {dataset_id}.{table_id}")
             tprint()


### PR DESCRIPTION
# Descrição
Quando os metadados de uma tabela são publicados no CKAN via `table-approve`, é preciso checar, antes, se os metadados do dataset correspondentes já existem no CKAN. Este PR adiciona esse passo a mais e a publicação do dataset caso ele ainda não exista no CKAN, consertando o passo de metadados da `table-approve`.