### PR TITLE
[infra] Conserta passo de publicação dos metadados na action `table-approve` [2]

### DIFF
--- a/.github/workflows/table-approve.yml
+++ b/.github/workflows/table-approve.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-table-approve-metadata-publish-2
 jobs:
   get-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/table-approve/table_approve.py
+++ b/.github/workflows/table-approve/table_approve.py
@@ -313,6 +313,9 @@ def table_approve():
             tprint()
         # pubish Metadata in prod
         try:
+            # create table metadata object
+            md = Metadata(dataset_id=dataset_id, table_id=table_id)
+            
             # check if correspondent dataset metadata already exists in CKAN 
             if not md.dataset_metadata_obj.exists_in_ckan():
                 # validate dataset metadata
@@ -333,10 +336,12 @@ def table_approve():
                     retry_count += 1
                     if retry_count >= MAX_RETRIES: break
                 
-                tprint(f"SUCESS PUBLISH {dataset_id}")
+                if md.dataset_metadata_obj.exists_in_ckan():
+                    tprint(f"SUCESS PUBLISH {dataset_id}")
+                else:
+                    tprint(f"ERROR PUBLISH {dataset_id}")
 
-            # create table metadata object and validate table metadata
-            md = Metadata(dataset_id=dataset_id, table_id=table_id)
+            # validate table metadata
             md.validate()
             tprint(f"SUCESS VALIDATE {dataset_id}.{table_id}")
             # publish table metadata to CKAN

--- a/.github/workflows/table-approve/table_approve.py
+++ b/.github/workflows/table-approve/table_approve.py
@@ -315,6 +315,14 @@ def table_approve():
             md = Metadata(dataset_id=dataset_id, table_id=table_id)
             md.validate()
             tprint(f"SUCESS VALIDATE {dataset_id}.{table_id}")
+            
+            if not md.dataset_metadata_obj.exists_in_ckan():
+                # validate and create dataset metadata in ckan first
+                md.dataset_metadata_obj.validate()
+                tprint(f"SUCESS VALIDATE {dataset_id}")
+                md.dataset_metadata_obj.publish()
+                tprint(f"SUCESS PUBLISH {dataset_id}")
+
             md.publish(if_exists="replace")
             tprint(f"SUCESS PUBLISHED {dataset_id}.{table_id}")
             tprint()

--- a/bases/test_dataset/dataset_config.yaml
+++ b/bases/test_dataset/dataset_config.yaml
@@ -39,4 +39,4 @@ github_url:
 
 # Não altere esse campo.
 # Data da última modificação dos metadados gerada automaticamente pelo CKAN.
-metadata_modified: '2021-11-23T20:30:05.260791'
+metadata_modified:

--- a/bases/test_dataset/dataset_config.yaml
+++ b/bases/test_dataset/dataset_config.yaml
@@ -3,7 +3,7 @@
 # Opções: escolher dessa lista -> https://basedosdados.org/api/3/action/organization_list
 # Exemplos: br-ibge, br-tse, br-rj-gov
 organization:
-    - basedosdados
+    - acaps
 
 dataset_id: test_dataset
 

--- a/bases/test_dataset/dataset_config.yaml
+++ b/bases/test_dataset/dataset_config.yaml
@@ -39,4 +39,4 @@ github_url:
 
 # Não altere esse campo.
 # Data da última modificação dos metadados gerada automaticamente pelo CKAN.
-metadata_modified: '2021-11-02T00:58:02.713310'
+metadata_modified: '2021-11-23T20:30:05.260791'

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -7,7 +7,7 @@ table_id: test_table
 # Você não precisa ser muito conciso. Sinta-se a vontade para dar exemplos de
 # como usar os dados.
 # Se souber, liste também aplicações: pesquisa, apps, etc. que usem os dados.,
-description: table-approve passou por aqui v1.0 -> teste com retries 
+description: table-approve passou por aqui v1.0 -> teste com retries  
 
 # A máxima unidade espacial que a tabela cobre.
 spatial_coverage:

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -7,7 +7,7 @@ table_id: test_table
 # Você não precisa ser muito conciso. Sinta-se a vontade para dar exemplos de
 # como usar os dados.
 # Se souber, liste também aplicações: pesquisa, apps, etc. que usem os dados.,
-description: table-approve passou por aqui v1.0 -> teste com retries
+description: table-approve passou por aqui v1.0 -> teste com retries 
 
 # A máxima unidade espacial que a tabela cobre.
 spatial_coverage:

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -7,7 +7,7 @@ table_id: test_table
 # Você não precisa ser muito conciso. Sinta-se a vontade para dar exemplos de
 # como usar os dados.
 # Se souber, liste também aplicações: pesquisa, apps, etc. que usem os dados.,
-description: table-approve passou por aqui v1.0 -> teste depois de deletar a tabela
+description: table-approve passou por aqui v1.0 -> teste com retries
 
 # A máxima unidade espacial que a tabela cobre.
 spatial_coverage:

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -157,4 +157,4 @@ columns:
       is_in_staging:
       is_partition:
 
-metadata_modified: '2021-11-02T01:45:13.586354'
+metadata_modified: 

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -7,7 +7,7 @@ table_id: test_table
 # Você não precisa ser muito conciso. Sinta-se a vontade para dar exemplos de
 # como usar os dados.
 # Se souber, liste também aplicações: pesquisa, apps, etc. que usem os dados.,
-description: table-approve passou por aqui v1.0
+description: table-approve passou por aqui v1.0 -> teste
 
 # A máxima unidade espacial que a tabela cobre.
 spatial_coverage:

--- a/bases/test_dataset/test_table/table_config.yaml
+++ b/bases/test_dataset/test_table/table_config.yaml
@@ -7,7 +7,7 @@ table_id: test_table
 # Você não precisa ser muito conciso. Sinta-se a vontade para dar exemplos de
 # como usar os dados.
 # Se souber, liste também aplicações: pesquisa, apps, etc. que usem os dados.,
-description: table-approve passou por aqui v1.0 -> teste
+description: table-approve passou por aqui v1.0 -> teste depois de deletar a tabela
 
 # A máxima unidade espacial que a tabela cobre.
 spatial_coverage:

--- a/python-package/tests/test_metadata.py
+++ b/python-package/tests/test_metadata.py
@@ -121,7 +121,7 @@ def test_create_partition_columns_from_existent_table(
     assert existent_metadata_path.exists()
 
     metadata_dict = existent_metadata.local_metadata
-    assert metadata_dict.get("partitions") == "ano, sigla_uf"
+    assert metadata_dict.get("partitions") == "ano, sigla_uf, id_municipio"
 
 
 def test_create_partition_columns_from_user_input(


### PR DESCRIPTION
# Descrição
Este PR recria o #981, na tentativa de debuggar a action `table-approve` e consertar seu passo de publicação de metadados.

# Lista de mudanças
- [x] Adiciona passo de publicação dos metadados do dataset antes da tabela caso ele não exista no CKAN
- [x] Adiciona retries para verificar se o dataset já foi publicado antes de tentar publicar a tabela

# Issues futuros
- Fazer o `table-approve` commitar os YAMLs atualizados pós-publicação de metadados