### PR TITLE
[infra] Faz o table-approve commitar os YAMLs atualizados após a publicação de novos metadados

### DIFF
--- a/.github/workflows/table-approve/table_approve.py
+++ b/.github/workflows/table-approve/table_approve.py
@@ -323,10 +323,10 @@ def table_approve():
                 tprint(f"SUCESS VALIDATE {dataset_id}")
                 
                 # publish dataset metadata to CKAN
-                md.dataset_metadata_obj.publish()
+                md.dataset_metadata_obj.publish(update_locally=True)
                 
-                # run multiple tries to get published dataset metadata from
-                # ckan till it is published: dataset metadata must be
+                # run multiple tries of getting published dataset metadata 
+                # from ckan till it is published: dataset metadata must be
                 # accessible for table metadata to be published too
                 tprint(f"WAITING FOR {dataset_id} METADATA PUBLISHMENT...")
                 MAX_RETRIES = 80
@@ -345,7 +345,7 @@ def table_approve():
             md.validate()
             tprint(f"SUCESS VALIDATE {dataset_id}.{table_id}")
             # publish table metadata to CKAN
-            md.publish(if_exists="replace")
+            md.publish(if_exists="replace", update_locally=True)
             tprint(f"SUCESS PUBLISHED {dataset_id}.{table_id}")
             tprint()
         except Exception as error:


### PR DESCRIPTION
# Descrição
Atualmente o `table-approve` consegue publicar novos metadados, mas não atualiza os YAMLs no GitHub (o campo `metadata-modified` é alterado pelo CKAN no momento da publicação). Isso causa uma complicação no workflow de subidorxs de dados, que precisam recriar o YAML após a publicação, caso tenham feito algum `git pull`. O problema está descrito no issue  #993.

A lista de tarefas a seguir propõe um caminho para resolver o problema. 

# Lista de tarefas
- [x] Fazer `table_approve.py` criar YAMLs locais durante a sessão corrente ao publicar novos metadados: `Metadata.publish(update_locally=True`
- [ ] Fazer novo passo na Action `table-approve` para que os dados criados localmente na sessão sejam commitados e pushados, atualizando os YAMLs do GitHub após a publicação no CKAN.
    - Usar action `checkout-v2` para esse passo, tal como descrito aqui: https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
- [ ] Verificar se é preciso fazer algo sobre os triggers do `table-approve` para evitar um loop infinito na hora de commitar novos metadados: quando a action checa as mudanças, ela considera os YAMLs também ou apenas os dados?