### PR TITLE
[dados-fix] `br_me_rais`: Update table_config.yaml

### DIFF
--- a/bases/br_me_rais/microdados_vinculos/table_config.yaml
+++ b/bases/br_me_rais/microdados_vinculos/table_config.yaml
@@ -79,7 +79,7 @@ last_updated:
 
 # Versão da tabela. Seguindo o padrão de semantic versioning.
 # Exemplo: v1.1.3
-version:
+version: v1.1
 
 # Quem está preenchendo esses metadados?
 published_by:


### PR DESCRIPTION
PR novo para re-rodar a action do `table approve` para `microdados_vinculos` que falhou no PR #1001.