### PR TITLE
Colab authentication

### DIFF
--- a/python-package/basedosdados/download/base.py
+++ b/python-package/basedosdados/download/base.py
@@ -4,8 +4,11 @@ Functions for manage auth and credentials
 # pylint: disable=redefined-outer-name, protected-access
 from functools import lru_cache
 
+import google.auth
+
 from google.cloud import bigquery, storage
 import pydata_google_auth
+
 
 from basedosdados.upload.base import Base
 
@@ -26,19 +29,24 @@ def reauth():
 
 def credentials(from_file=False, reauth=False):
     '''
-    Get user credentials
+    Get user credentials with google.auth
     '''
 
     if from_file:
         return Base()._load_credentials(mode="prod")
 
     if reauth:
-        return pydata_google_auth.get_user_credentials(
-            SCOPES, credentials_cache=pydata_google_auth.cache.REAUTH
+        credentials_, _ = google.auth.default(
+            scopes=SCOPES,
+            # credentials_cache=None,
         )
-    return pydata_google_auth.get_user_credentials(
-        SCOPES,
+        return credentials_
+
+    credentials_, _ = google.auth.default(
+        scopes=SCOPES
     )
+    return credentials_
+
 
 
 @lru_cache(256)

--- a/python-package/basedosdados/download/base.py
+++ b/python-package/basedosdados/download/base.py
@@ -4,7 +4,7 @@ Functions for manage auth and credentials
 # pylint: disable=redefined-outer-name, protected-access
 from functools import lru_cache
 
-import google.auth
+import sys
 
 from google.cloud import bigquery, storage
 import pydata_google_auth
@@ -29,24 +29,30 @@ def reauth():
 
 def credentials(from_file=False, reauth=False):
     '''
-    Get user credentials with google.auth
+    Get user credentials
     '''
 
+    # check if is running in colab
+    if "google.colab" in sys.modules:
+        # authenticate from google colab
+
+        # pylint: disable=no-name-in-module, import-outside-toplevel, import-error
+        from google.colab import auth
+        auth.authenticate_user()
+        return None
+
+    #Authenticate from PyData, for compatibility reasons
     if from_file:
         return Base()._load_credentials(mode="prod")
 
     if reauth:
-        credentials_, _ = google.auth.default(
-            scopes=SCOPES,
-            # credentials_cache=None,
+        return pydata_google_auth.get_user_credentials(
+            SCOPES, credentials_cache=pydata_google_auth.cache.REAUTH
         )
-        return credentials_
 
-    credentials_, _ = google.auth.default(
-        scopes=SCOPES
+    return pydata_google_auth.get_user_credentials(
+            SCOPES,
     )
-    return credentials_
-
 
 
 @lru_cache(256)

--- a/python-package/basedosdados/download/base.py
+++ b/python-package/basedosdados/download/base.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 import sys
 
 from google.cloud import bigquery, storage
-from google.colab import auth
 
 import pydata_google_auth
 
@@ -36,6 +35,7 @@ def credentials(from_file=False, reauth=False):
 
     #check if is running in colab
     if "google.colab" in sys.modules:
+        from google.colab import auth  # pylint: disable=import-outside-toplevel
         auth.authenticate_user()
         return None
 

--- a/python-package/basedosdados/download/base.py
+++ b/python-package/basedosdados/download/base.py
@@ -1,12 +1,14 @@
 '''
 Functions for manage auth and credentials
 '''
-# pylint: disable=redefined-outer-name, protected-access
+# pylint: disable=redefined-outer-name, protected-access, no-name-in-module, import-error
 from functools import lru_cache
 
 import sys
 
 from google.cloud import bigquery, storage
+from google.colab import auth
+
 import pydata_google_auth
 
 
@@ -34,22 +36,20 @@ def credentials(from_file=False, reauth=False):
 
     #check if is running in colab
     if "google.colab" in sys.modules:
-        print("Autenticando via Colab")
-        from google.colab import auth
         auth.authenticate_user()
         return None
-    else:
-        if from_file:
-            return Base()._load_credentials(mode="prod")
 
-        if reauth:
-            return pydata_google_auth.get_user_credentials(
-                SCOPES, credentials_cache=pydata_google_auth.cache.REAUTH
-            )
+    if from_file:
+        return Base()._load_credentials(mode="prod")
 
+    if reauth:
         return pydata_google_auth.get_user_credentials(
-                SCOPES,
+            SCOPES, credentials_cache=pydata_google_auth.cache.REAUTH
         )
+
+    return pydata_google_auth.get_user_credentials(
+            SCOPES,
+    )
 
 
 

--- a/python-package/basedosdados/download/base.py
+++ b/python-package/basedosdados/download/base.py
@@ -29,33 +29,27 @@ def reauth():
 
 def credentials(from_file=False, reauth=False):
     '''
-    Get user credentials with google.auth
+    Get user credentials
     '''
 
-    # check if is running in colab
+    #check if is running in colab
     if "google.colab" in sys.modules:
-        # authenticate from google colab
-
-        # pylint: disable=no-name-in-module, import-outside-toplevel, import-error
+        print("Autenticando via Colab")
         from google.colab import auth
         auth.authenticate_user()
         return None
+    else:
+        if from_file:
+            return Base()._load_credentials(mode="prod")
 
-    #Authenticate from PyData, for compatibility reasons
-    if from_file:
-        return Base()._load_credentials(mode="prod")
+        if reauth:
+            return pydata_google_auth.get_user_credentials(
+                SCOPES, credentials_cache=pydata_google_auth.cache.REAUTH
+            )
 
-    if reauth:
-        credentials_, _ = google.auth.default(
-            scopes=SCOPES,
-            # credentials_cache=None,
+        return pydata_google_auth.get_user_credentials(
+                SCOPES,
         )
-
-    return pydata_google_auth.get_user_credentials(
-            SCOPES,
-
-    )
-    return credentials_
 
 
 

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/base-dos-dados/bases"
-version = "1.6.5-beta.2"
+version = "1.6.5-beta.3"
 
 [tool.poetry.scripts]
 basedosdados = 'basedosdados.cli.cli:cli'

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/base-dos-dados/bases"
-version = "1.6.5-beta.1"
+version = "1.6.5-beta.2"
 
 [tool.poetry.scripts]
 basedosdados = 'basedosdados.cli.cli:cli'


### PR DESCRIPTION
Conforme reportado nos testes, o módulo ``google.colab`` só pode ser importado quando estiver no ambiente do ``colab``, nunca localmente. Refiz a importação para que ela não ocorra localmente.