### PR TITLE
[infra] expoe parametro para gerar `table_config.yaml` a partir dos dados locais

### DIFF
--- a/python-package/basedosdados/cli/cli.py
+++ b/python-package/basedosdados/cli/cli.py
@@ -222,6 +222,11 @@ def cli_table():
     help="Data source format. Only 'csv' is supported. Defaults to 'csv'.",
 )
 @click.option(
+    "--force_columns",
+    default=False,
+    help="Overwrite columns with local columns.",
+)
+@click.option(
     "--columns_config_url_or_path",
     default=None,
     help="google sheets URL. Must be in the format https://docs.google.com/spreadsheets/d/<table_key>/edit#gid=<table_gid>. The sheet must contain the column name: 'coluna' and column description: 'descricao'.",
@@ -235,6 +240,7 @@ def init_table(
     if_folder_exists,
     if_table_config_exists,
     source_format,
+    force_columns,
     columns_config_url_or_path,
 ):
     """
@@ -246,6 +252,7 @@ def init_table(
         if_folder_exists=if_folder_exists,
         if_table_config_exists=if_table_config_exists,
         source_format=source_format,
+        force_columns=force_columns,
         columns_config_url_or_path=columns_config_url_or_path,
     )
 
@@ -293,6 +300,11 @@ def init_table(
     help="Data source format. Only 'csv' is supported. Defaults to 'csv'.",
 )
 @click.option(
+    "--force_columns",
+    default=False,
+    help="Overwrite columns with local columns.",
+)
+@click.option(
     "--columns_config_url_or_path",
     default=None,
     help="Path to the local architeture file or a public google sheets URL. Path only suports csv, xls, xlsx, xlsm, xlsb, odf, ods, odt formats. Google sheets URL must be in the format https://docs.google.com/spreadsheets/d/<table_key>/edit#gid=<table_gid>.",
@@ -323,6 +335,7 @@ def create_table(
     if_storage_data_exists,
     if_table_config_exists,
     source_format,
+    force_columns,
     columns_config_url_or_path,
     dataset_is_public,
     location,
@@ -340,6 +353,7 @@ def create_table(
         if_storage_data_exists=if_storage_data_exists,
         if_table_config_exists=if_table_config_exists,
         source_format=source_format,
+        force_columns=force_columns,
         columns_config_url_or_path=columns_config_url_or_path,
         dataset_is_public=dataset_is_public,
         location=location,

--- a/python-package/basedosdados/upload/table.py
+++ b/python-package/basedosdados/upload/table.py
@@ -218,12 +218,13 @@ class Table(Base):
             publish_txt
         )
 
-    def _make_template(self, columns, partition_columns, if_table_config_exists):
+    def _make_template(self, columns, partition_columns, if_table_config_exists, force_columns):
         # create table_config.yaml with metadata
         self.metadata.create(
             if_exists=if_table_config_exists,
             columns=partition_columns + columns,
             partition_columns=partition_columns,
+            force_columns=force_columns,
             table_only=False,
         )
 
@@ -415,8 +416,9 @@ class Table(Base):
         if_folder_exists="raise",
         if_table_config_exists="raise",
         source_format="csv",
+        force_columns = False,
         columns_config_url_or_path=None,
-    ):
+    ):  # sourcery skip: low-code-quality
         """Initialize table folder at metadata_path at `metadata_path/<dataset_id>/<table_id>`.
 
         The folder should contain:
@@ -446,7 +448,11 @@ class Table(Base):
             source_format (str): Optional
                 Data source format. Only 'csv', 'avro' and 'parquet'
                 are supported. Defaults to 'csv'.
-
+            force_columns (bool): Optional.
+                If set to `True`, overwrite CKAN's columns with the ones provi
+                ded.
+                If set to `False`, keep CKAN's columns instead of the ones pro
+                vided.
             columns_config_url_or_path (str): Path to the local architeture file or a public google sheets URL.
                 Path only suports csv, xls, xlsx, xlsm, xlsb, odf, ods, odt formats.
                 Google sheets URL must be in the format https://docs.google.com/spreadsheets/d/<table_key>/edit#gid=<table_gid>.
@@ -521,7 +527,7 @@ class Table(Base):
                     "You must provide a path to correctly create config files"
                 )
             else:
-                self._make_template(columns, partition_columns, if_table_config_exists)
+                self._make_template(columns, partition_columns, if_table_config_exists, force_columns=force_columns)
 
         elif if_table_config_exists == "raise":
 
@@ -535,11 +541,11 @@ class Table(Base):
                     f"table_config.yaml and publish.sql already exists at {self.table_folder}"
                 )
             # if config files don't exist, create them
-            self._make_template(columns, partition_columns, if_table_config_exists)
+            self._make_template(columns, partition_columns, if_table_config_exists, force_columns=force_columns)
 
         else:
             # Raise: without a path to data sample, should not replace config files with empty template
-            self._make_template(columns, partition_columns, if_table_config_exists)
+            self._make_template(columns, partition_columns, if_table_config_exists, force_columns=force_columns)
 
         if columns_config_url_or_path is not None:
             self.update_columns(columns_config_url_or_path)
@@ -554,6 +560,7 @@ class Table(Base):
         if_storage_data_exists="raise",
         if_table_config_exists="raise",
         source_format="csv",
+        force_columns=False,
         columns_config_url_or_path=None,
         dataset_is_public=True,
         location=None,
@@ -607,7 +614,11 @@ class Table(Base):
             source_format (str): Optional
                 Data source format. Only 'csv', 'avro' and 'parquet'
                 are supported. Defaults to 'csv'.
-
+            force_columns (bool): Optional.
+                If set to `True`, overwrite CKAN's columns with the ones provi
+                ded.
+                If set to `False`, keep CKAN's columns instead of the ones pro
+                vided.
             columns_config_url_or_path (str): Path to the local architeture file or a public google sheets URL.
                 Path only suports csv, xls, xlsx, xlsm, xlsb, odf, ods, odt formats.
                 Google sheets URL must be in the format https://docs.google.com/spreadsheets/d/<table_key>/edit#gid=<table_gid>.
@@ -672,6 +683,7 @@ class Table(Base):
             if_table_config_exists=if_table_config_exists,
             columns_config_url_or_path=columns_config_url_or_path,
             source_format=source_format,
+            force_columns=force_columns
         )
 
         table = bigquery.Table(self.table_full_name["staging"])


### PR DESCRIPTION
### Descrição

Hoje ao utilizar o `Table.create` não se tem a opção de ignorar os metadados do ckan e gerar um novo `table_config.yaml` a partir do arquivo local. No entando essa feature já existe para o `Metadata.create`, expor o parametro `force_columns` no `Table.create` pode ser uma solução


- [x] Expoe parametro `force_columns` do `Metadata.create` no `Table.create`
- [x] Adicionar novo parametro `force_columns` na CLI
- [ ] Testar