### PR TITLE
fix `_set_config_variables` is not defined

### DIFF
--- a/python-package/basedosdados/download/download.py
+++ b/python-package/basedosdados/download/download.py
@@ -1,6 +1,7 @@
 """
 Functions for managing downloads
 """
+
 import gzip
 import os
 import re
@@ -24,6 +25,19 @@ from pandas_gbq import read_gbq
 from pandas_gbq.gbq import GenericGBQException
 from pydata_google_auth import cache, get_user_credentials
 from pydata_google_auth.exceptions import PyDataCredentialsError
+
+
+def _set_config_variables(billing_project_id, from_file):
+    """
+    Set billing_project_id and from_file variables
+    """
+
+    # standard billing_project_id configuration
+    billing_project_id = billing_project_id or config.billing_project_id
+    # standard from_file configuration
+    from_file = from_file or config.from_file
+
+    return billing_project_id, from_file
 
 
 def read_sql(
@@ -67,9 +81,9 @@ def read_sql(
 
         return read_gbq(
             query,
-            project_id=config.billing_project_id,
+            project_id=billing_project_id,
             use_bqstorage_api=use_bqstorage_api,
-            credentials=_credentials(from_file=config.from_file, reauth=reauth),
+            credentials=_credentials(from_file=from_file, reauth=reauth),
         )
     except GenericGBQException as e:
         if "Reason: 403" in str(e):


### PR DESCRIPTION
Introduzido em https://github.com/basedosdados/mais/pull/1712. A função foi removida

Reproduzindo:
```
cd /tmp
mkdir bd-beta-21
cd bd-beta-21
```

```
python -m venv .venv
source .venv/bin/activate
python -m pip install "basedosdados[upload]==2.0.0b21"
```

```
python --version                                      
Python 3.9.17
```

```
touch test.py
```

`test.py`:

```python
import basedosdados as bd

df = bd.read_sql(
    "select * from `basedosdados-dev.br_inep_saeb_staging.dicionario`",
    billing_project_id="basedosdados-dev",
)

print(df)
```

`python test.py`

```
Traceback (most recent call last):
  File "/tmp/bd-beta-21/test.py", line 3, in <module>
    df = bd.read_sql(
  File "/tmp/bd-beta-21/.venv/lib/python3.9/site-packages/basedosdados/download/download.py", line 57, in read_sql
    billing_project_id, from_file = _set_config_variables(
NameError: name '_set_config_variables' is not defined

```