### PR TITLE
[docs] Atualiza instrução para fixar projeto no BQ

### DIFF
--- a/docs/docs/access_data_bq.md
+++ b/docs/docs/access_data_bq.md
@@ -51,6 +51,8 @@ hover="background-color: var(--md-primary-fg-color--dark)">
 
 Agora você precisa fixar o projeto da BD no seu BigQuery, é bem simples, veja:
 
+!!! Warning A opção **Fixar um projeto** pode aparccer também como **Marcar projeto com estrela por nome**
+
 ![](images/bq_access_project_new.gif)
 
 Dentro do projeto existem dois níveis de organização dos dados,

--- a/docs/docs/access_data_bq.md
+++ b/docs/docs/access_data_bq.md
@@ -51,7 +51,7 @@ hover="background-color: var(--md-primary-fg-color--dark)">
 
 Agora você precisa fixar o projeto da BD no seu BigQuery, é bem simples, veja:
 
-!!! Warning A opção **Fixar um projeto** pode aparccer também como **Marcar projeto com estrela por nome**
+!!! Warning A opção **Fixar um projeto** pode aparecer também como **Marcar projeto com estrela por nome**
 
 ![](images/bq_access_project_new.gif)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,7 +29,7 @@ theme:
     - toc.integrate
     - navigation.tabs
 
-repo_url: https://github.com/basedosdados/mais
+repo_url: https://github.com/basedosdados/mais/docs/
 repo_name: basedosdados/mais
 
 extra:


### PR DESCRIPTION
* [ccadd59](https://github.com/basedosdados/mais/pull/1730/commits/ccadd591dd1db615553e0487e1d5f3738c1d1292), [06f7a51](https://github.com/basedosdados/mais/pull/1730/commits/06f7a5180c883198fa94a983aae4902a25c46c73): Pedido do Hidelbrando pelo grupo do whatsapp, estava com dificuldade de fixar o projeto pois a nomenclatura do BQ mudou!

* [ebab189](https://github.com/basedosdados/mais/pull/1730/commits/ebab189f4b386ac1be46802c32c6e7413e9a5171): Aproveitei para corrigir tb a opção de edição de página, que estava com o link quebrado quando clica no botão de Editar (print abaixo). https://github.com/mkdocs/mkdocs/issues/1321

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/032c94af-1dd0-460e-9002-86a59db4f2b8">
