### PR TITLE
[infra] python: add `Table.create_from_pandas`

### DIFF
--- a/python-package/basedosdados/upload/table.py
+++ b/python-package/basedosdados/upload/table.py
@@ -4,6 +4,7 @@ Class for manage tables in Storage and BigQuery.
 
 import contextlib
 import inspect
+import tempfile
 import textwrap
 from copy import deepcopy
 from functools import lru_cache
@@ -11,16 +12,21 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import google.api_core.exceptions
+import pandas as pd
 from google.cloud import bigquery
 from google.cloud.bigquery import SchemaField
 from loguru import logger
 
 from basedosdados.core.base import Base
-from basedosdados.exceptions import BaseDosDadosException
+from basedosdados.exceptions import (
+    BaseDosDadosException,
+    BaseDosDadosMissingDependencyException,
+)
 from basedosdados.upload.connection import Connection
 from basedosdados.upload.dataset import Dataset
 from basedosdados.upload.datatypes import Datatype
 from basedosdados.upload.storage import Storage
+from basedosdados.upload.utils import to_partitions
 
 
 class Table(Base):
@@ -498,6 +504,98 @@ class Table(Base):
                 description = "description not available in the API."
 
         return description
+
+    def create_from_pandas(
+        self,
+        df: pd.DataFrame,
+        partition_columns: Optional[list[str]] = None,
+        source_format: str = "csv",
+        **kwargs,
+    ) -> None:
+        """
+        Creates a BigQuery staging table directly from a pandas DataFrame.
+
+        This is a convenience wrapper around `Table.create` that saves the
+        DataFrame to a temporary location and uploads it, so you don't have to
+        manage files or partition folders yourself. When `partition_columns` is
+        provided, the data is written following the Hive partitioning scheme
+        (`<key1>=<value1>/<key2>=<value2>`) before being uploaded.
+
+        The following data formats are supported:
+
+        - Comma-Delimited CSV
+        - Apache Parquet
+        - Apache Avro
+
+        Args:
+            df: The pandas DataFrame to upload and create the table from.
+            partition_columns: A list of column names to partition the data by.
+                These columns are removed from the data files and encoded in the
+                storage path following the Hive partitioning scheme.
+            source_format: The format used to save the data. Only 'csv',
+                'parquet' and 'avro' are supported. Defaults to 'csv'.
+            **kwargs: Additional keyword arguments forwarded to `Table.create`
+                (e.g. `if_table_exists`, `if_storage_data_exists`,
+                `if_dataset_exists`, `biglake_table`, `location`, etc.).
+        """
+        if not isinstance(df, pd.DataFrame):
+            raise BaseDosDadosException("`df` must be a pandas DataFrame.")
+
+        if source_format not in ("csv", "parquet", "avro"):
+            raise BaseDosDadosException(
+                "`source_format` must be one of 'csv', 'parquet' or 'avro'."
+            )
+
+        if source_format == "avro":
+            try:
+                import pandavro  # noqa: F401
+            except ImportError as exc:
+                raise BaseDosDadosMissingDependencyException(
+                    "Optional dependencies for handling AVRO files are not installed. "
+                    'Please install basedosdados with the "avro" extra'
+                ) from exc
+
+        partition_columns = partition_columns or []
+        missing_columns = [
+            col for col in partition_columns if col not in df.columns
+        ]
+        if missing_columns:
+            raise BaseDosDadosException(
+                f"Partition columns not found in the DataFrame: {missing_columns}"
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            logger.info(
+                "Saving DataFrame to temporary directory: {tmpdir}",
+                tmpdir=tmpdir,
+            )
+
+            if partition_columns:
+                to_partitions(
+                    data=df,
+                    partition_columns=partition_columns,
+                    savepath=tmppath,
+                    file_format=source_format,
+                )
+                path = tmppath
+            else:
+                path = tmppath / f"data.{source_format}"
+                if source_format == "csv":
+                    df.to_csv(path, index=False)
+                elif source_format == "parquet":
+                    df.to_parquet(path, index=False)
+                else:
+                    import pandavro
+
+                    pandavro.to_avro(str(path), df)
+
+            self.create(
+                path=path,
+                source_format=source_format,
+                **kwargs,
+            )
 
     def create(
         self,

--- a/python-package/basedosdados/upload/table.py
+++ b/python-package/basedosdados/upload/table.py
@@ -509,6 +509,7 @@ class Table(Base):
         self,
         df: pd.DataFrame,
         partition_columns: Optional[list[str]] = None,
+        file_name: str = "data",
         source_format: str = "csv",
         **kwargs,
     ) -> None:
@@ -532,6 +533,7 @@ class Table(Base):
             partition_columns: A list of column names to partition the data by.
                 These columns are removed from the data files and encoded in the
                 storage path following the Hive partitioning scheme.
+            file_name: Name of file without extension. Defaults to `data`.
             source_format: The format used to save the data. Only 'csv',
                 'parquet' and 'avro' are supported. Defaults to 'csv'.
             **kwargs: Additional keyword arguments forwarded to `Table.create`
@@ -559,7 +561,7 @@ class Table(Base):
         missing_columns = [
             col for col in partition_columns if col not in df.columns
         ]
-        if missing_columns:
+        if len(missing_columns) > 0:
             raise BaseDosDadosException(
                 f"Partition columns not found in the DataFrame: {missing_columns}"
             )
@@ -572,16 +574,17 @@ class Table(Base):
                 tmpdir=tmpdir,
             )
 
-            if partition_columns:
+            if len(partition_columns) > 0:
                 to_partitions(
                     data=df,
                     partition_columns=partition_columns,
                     savepath=tmppath,
+                    file_name=file_name,
                     file_format=source_format,
                 )
                 path = tmppath
             else:
-                path = tmppath / f"data.{source_format}"
+                path = tmppath / f"{file_name}.{source_format}"
                 if source_format == "csv":
                     df.to_csv(path, index=False)
                 elif source_format == "parquet":

--- a/python-package/basedosdados/upload/utils.py
+++ b/python-package/basedosdados/upload/utils.py
@@ -6,15 +6,22 @@ from typing import List
 
 import pandas as pd
 
+from basedosdados.exceptions import BaseDosDadosMissingDependencyException
+
 
 def to_partitions(
-    data: pd.DataFrame, partition_columns: List[str], savepath: str
+    data: pd.DataFrame,
+    partition_columns: List[str],
+    savepath: str,
+    file_format: str = "csv",
 ):
     """Save data in to hive patitions schema, given a dataframe and a list of partition columns.
     Args:
         data (pandas.core.frame.DataFrame): Dataframe to be partitioned.
         partition_columns (list): List of columns to be used as partitions.
         savepath (str, pathlib.PosixPath): folder path to save the partitions
+        file_format (str): The file format to save the partitioned data in.
+            Only 'csv', 'parquet' and 'avro' are supported. Defaults to 'csv'.
     Exemple:
         data = {
             "ano": [2020, 2021, 2020, 2021, 2020, 2021, 2021,2025],
@@ -57,15 +64,33 @@ def to_partitions(
             # create folder tree
             filter_save_path = Path(savepath / "/".join(patitions_values))
             filter_save_path.mkdir(parents=True, exist_ok=True)
-            file_filter_save_path = Path(filter_save_path) / "data.csv"
 
-            # append data to csv
-            df_filter.to_csv(
-                file_filter_save_path,
-                index=False,
-                mode="a",
-                header=not file_filter_save_path.exists(),
-            )
+            if file_format == "csv":
+                file_filter_save_path = Path(filter_save_path) / "data.csv"
+                # append data to csv
+                df_filter.to_csv(
+                    file_filter_save_path,
+                    index=False,
+                    mode="a",
+                    header=not file_filter_save_path.exists(),
+                )
+            elif file_format == "parquet":
+                file_filter_save_path = Path(filter_save_path) / "data.parquet"
+                df_filter.to_parquet(file_filter_save_path, index=False)
+            elif file_format == "avro":
+                try:
+                    import pandavro
+                except ImportError as exc:
+                    raise BaseDosDadosMissingDependencyException(
+                        "Optional dependencies for handling AVRO files are not installed. "
+                        'Please install basedosdados with the "avro" extra'
+                    ) from exc
+                file_filter_save_path = Path(filter_save_path) / "data.avro"
+                pandavro.to_avro(str(file_filter_save_path), df_filter)
+            else:
+                raise NotImplementedError(
+                    "Base dos Dados just supports csv, parquet and avro files"
+                )
     else:
         raise BaseException("Data need to be a pandas DataFrame")
 

--- a/python-package/basedosdados/upload/utils.py
+++ b/python-package/basedosdados/upload/utils.py
@@ -13,6 +13,7 @@ def to_partitions(
     data: pd.DataFrame,
     partition_columns: List[str],
     savepath: str,
+    file_name: str = "data",
     file_format: str = "csv",
 ):
     """Save data in to hive patitions schema, given a dataframe and a list of partition columns.
@@ -20,6 +21,7 @@ def to_partitions(
         data (pandas.core.frame.DataFrame): Dataframe to be partitioned.
         partition_columns (list): List of columns to be used as partitions.
         savepath (str, pathlib.PosixPath): folder path to save the partitions
+        file_name: Name of file without extension.
         file_format (str): The file format to save the partitioned data in.
             Only 'csv', 'parquet' and 'avro' are supported. Defaults to 'csv'.
     Exemple:
@@ -66,16 +68,17 @@ def to_partitions(
             filter_save_path.mkdir(parents=True, exist_ok=True)
 
             if file_format == "csv":
-                file_filter_save_path = Path(filter_save_path) / "data.csv"
-                # append data to csv
+                file_filter_save_path = (
+                    Path(filter_save_path) / f"{file_name}.csv"
+                )
                 df_filter.to_csv(
                     file_filter_save_path,
                     index=False,
-                    mode="a",
-                    header=not file_filter_save_path.exists(),
                 )
             elif file_format == "parquet":
-                file_filter_save_path = Path(filter_save_path) / "data.parquet"
+                file_filter_save_path = (
+                    Path(filter_save_path) / f"{file_name}.parquet"
+                )
                 df_filter.to_parquet(file_filter_save_path, index=False)
             elif file_format == "avro":
                 try:
@@ -85,7 +88,9 @@ def to_partitions(
                         "Optional dependencies for handling AVRO files are not installed. "
                         'Please install basedosdados with the "avro" extra'
                     ) from exc
-                file_filter_save_path = Path(filter_save_path) / "data.avro"
+                file_filter_save_path = (
+                    Path(filter_save_path) / f"{file_name}.avro"
+                )
                 pandavro.to_avro(str(file_filter_save_path), df_filter)
             else:
                 raise NotImplementedError(

--- a/python-package/tests/test_table.py
+++ b/python-package/tests/test_table.py
@@ -320,6 +320,13 @@ def test_create_from_pandas_partitioned():
 
     assert table.table_exists("staging")
 
+    # Check the table is partitioned using the BigQuery python API
+    bq_table = table._get_table_obj("staging")
+    hive_partitioning = bq_table.external_data_configuration.hive_partitioning
+
+    assert hive_partitioning is not None
+    assert hive_partitioning.mode == "STRINGS"
+
 
 @pytest.mark.order2
 def test_create_from_pandas_parquet():

--- a/python-package/tests/test_table.py
+++ b/python-package/tests/test_table.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from basedosdados.exceptions import BaseDosDadosException
@@ -281,6 +282,95 @@ def test_table_create_with_avro_source_format(capsys):
     )
     _, out = capsys.readouterr()
     assert "File municipio.avro_staging was uploaded!" in out
+
+
+@pytest.mark.order2
+def test_create_from_pandas():
+    """
+    Test create_from_pandas creates a staging table from a DataFrame
+    """
+
+    df = pd.read_csv(csv_path)
+
+    table.create_from_pandas(
+        df=df,
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="replace",
+    )
+
+    assert table.table_exists("staging")
+
+
+@pytest.mark.order2
+def test_create_from_pandas_partitioned():
+    """
+    Test create_from_pandas with partition columns
+    """
+
+    df = pd.read_csv(csv_path)
+
+    table.create_from_pandas(
+        df=df,
+        partition_columns=["ano"],
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="replace",
+    )
+
+    assert table.table_exists("staging")
+    assert table._is_partitioned() is True
+
+
+@pytest.mark.order2
+def test_create_from_pandas_parquet():
+    """
+    Test create_from_pandas when source format is parquet
+    """
+
+    df = pd.read_csv(csv_path)
+
+    table.create_from_pandas(
+        df=df,
+        source_format="parquet",
+        if_table_exists="replace",
+        if_storage_data_exists="replace",
+        if_dataset_exists="replace",
+    )
+
+    assert table.table_exists("staging")
+
+
+def test_create_from_pandas_invalid_df():
+    """
+    Test create_from_pandas raises when df is not a DataFrame
+    """
+
+    with pytest.raises(BaseDosDadosException):
+        table.create_from_pandas(df="not a dataframe")
+
+
+def test_create_from_pandas_invalid_source_format():
+    """
+    Test create_from_pandas raises for an unsupported source format
+    """
+
+    with pytest.raises(BaseDosDadosException):
+        table.create_from_pandas(
+            df=pd.DataFrame({"a": [1]}), source_format="json"
+        )
+
+
+def test_create_from_pandas_missing_partition_column():
+    """
+    Test create_from_pandas raises when a partition column is not in the df
+    """
+
+    with pytest.raises(BaseDosDadosException):
+        table.create_from_pandas(
+            df=pd.DataFrame({"a": [1]}),
+            partition_columns=["does_not_exist"],
+        )
 
 
 @pytest.mark.order2

--- a/python-package/tests/test_table.py
+++ b/python-package/tests/test_table.py
@@ -319,7 +319,6 @@ def test_create_from_pandas_partitioned():
     )
 
     assert table.table_exists("staging")
-    assert table._is_partitioned() is True
 
 
 @pytest.mark.order2


### PR DESCRIPTION
## Resumo 
Adiciona o método `Table.create_from_pandas`, um atalho que cria uma tabela de staging no BigQuery diretamente a partir de um DataFrame do pandas, sem exigir que a pessoa escreva arquivos manualmente ou monte a estrutura de pastas de partição.

```python
from basedosdados import Table

table = Table(dataset_id="my_dataset", table_id="my_table")

# arquivo único
table.create_from_pandas(df, if_table_exists="replace")

# particionado (esquema Hive)
table.create_from_pandas(df, partition_columns=["ano", "sigla_uf"])

# parquet / avro
table.create_from_pandas(df, source_format="parquet")
```

Close #1774 